### PR TITLE
Stun turn from worker

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ var IsMonitor = flag.Bool("monitor", false, "Turn on monitor")
 var FrontendSTUNTURN = flag.String("stunturn", DefaultSTUNTURN, "Frontend STUN TURN servers")
 var Mode = flag.String("mode", "dev", "Environment")
 var IsRetro = flag.Bool("isretro", true, "Is retro")
+var StunTurnTemplate = `[{"urls":"stun:%s:3478"},{"urls":"turn:%s:3478","username":"root","credential":"root"}]`
 
 var WSWait = 20 * time.Second
 var MatchWorkerRandom = false

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ var IsMonitor = flag.Bool("monitor", false, "Turn on monitor")
 var FrontendSTUNTURN = flag.String("stunturn", DefaultSTUNTURN, "Frontend STUN TURN servers")
 var Mode = flag.String("mode", "dev", "Environment")
 var IsRetro = flag.Bool("isretro", true, "Is retro")
-var StunTurnTemplate = `[{"urls":"stun:%s:3478"},{"urls":"turn:%s:3478","username":"root","credential":"root"}]`
+var StunTurnTemplate = `[{"urls":"stun:stun.l.google.com:19302"},{"urls":"stun:%s:3478"},{"urls":"turn:%s:3478","username":"root","credential":"root"}]`
 
 var WSWait = 20 * time.Second
 var MatchWorkerRandom = false

--- a/overlord/gamelist/games.go
+++ b/overlord/gamelist/games.go
@@ -1,8 +1,6 @@
 package gamelist
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -22,11 +20,4 @@ func GetGameList(gamePath string) []string {
 	})
 
 	return games
-}
-
-// GetEncodedGameList returns game list in encoded wspacket format
-func GetEncodedGameList(gamePath string) string {
-	encodedList, _ := json.Marshal(GetGameList(gamePath))
-	fmt.Println(encodedList)
-	return string(encodedList)
 }

--- a/overlord/handlers.go
+++ b/overlord/handlers.go
@@ -91,7 +91,7 @@ func (o *Server) WSO(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	client := NewWorkerClient(c, serverID, address)
+	client := NewWorkerClient(c, serverID, address, config.DefaultSTUNTURN)
 	o.workerClients[serverID] = client
 	defer o.cleanConnection(client, serverID)
 
@@ -160,8 +160,8 @@ func (o *Server) WS(w http.ResponseWriter, r *http.Request) {
 	wssession.RouteBrowser()
 
 	wssession.BrowserClient.Send(cws.WSPacket{
-		ID:   "gamelist",
-		Data: gamelist.GetEncodedGameList(gamePath),
+		ID:   "init",
+		Data: createInitPackage(o.workerClients[serverID].StunTurnServer, gamePath),
 	}, nil)
 
 	// If peerconnection is done (client.Done is signalled), we close peerconnection
@@ -272,6 +272,8 @@ func getLatencyMapFromBrowser(workerClients map[string]*WorkerClient, client *Br
 	return latencyMap
 }
 
+// cleanConnection is called when a worker is disconnected
+// connection from worker (client) to server is also closed
 func (o *Server) cleanConnection(client *WorkerClient, serverID string) {
 	log.Println("Unregister server from overlord")
 	// Remove serverID from servers
@@ -284,4 +286,13 @@ func (o *Server) cleanConnection(client *WorkerClient, serverID string) {
 	}
 
 	client.Close()
+}
+
+// createInitPackage returns serverhost + game list in encoded wspacket format
+// This package will be sent to initialize
+func createInitPackage(stunturn, gamePath string) string {
+	gameList := gamelist.GetGameList(gamePath)
+	initPackage := append([]string{stunturn}, gameList...)
+	encodedList, _ := json.Marshal(initPackage)
+	return string(encodedList)
 }

--- a/overlord/handlers.go
+++ b/overlord/handlers.go
@@ -91,7 +91,7 @@ func (o *Server) WSO(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	client := NewWorkerClient(c, serverID, address, config.DefaultSTUNTURN)
+	client := NewWorkerClient(c, serverID, address, fmt.Sprintf(config.StunTurnTemplate, address, address))
 	o.workerClients[serverID] = client
 	defer o.cleanConnection(client, serverID)
 

--- a/overlord/worker.go
+++ b/overlord/worker.go
@@ -1,6 +1,7 @@
 package overlord
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/giongto35/cloud-game/cws"
@@ -44,6 +45,7 @@ func (o *Server) RouteWorker(workerClient *WorkerClient) {
 
 // NewWorkerClient returns a client connecting to worker. This connection exchanges information between workers and server
 func NewWorkerClient(c *websocket.Conn, serverID string, address string, stunturn string) *WorkerClient {
+	fmt.Println("STUN TURN WORKER", stunturn)
 	return &WorkerClient{
 		Client:         cws.NewClient(c),
 		ServerID:       serverID,

--- a/overlord/worker.go
+++ b/overlord/worker.go
@@ -9,9 +9,10 @@ import (
 
 type WorkerClient struct {
 	*cws.Client
-	ServerID    string
-	Address     string
-	IsAvailable bool
+	ServerID       string
+	Address        string
+	StunTurnServer string
+	IsAvailable    bool
 }
 
 // RouteWorker are all routes server received from worker
@@ -42,11 +43,12 @@ func (o *Server) RouteWorker(workerClient *WorkerClient) {
 }
 
 // NewWorkerClient returns a client connecting to worker. This connection exchanges information between workers and server
-func NewWorkerClient(c *websocket.Conn, serverID string, address string) *WorkerClient {
+func NewWorkerClient(c *websocket.Conn, serverID string, address string, stunturn string) *WorkerClient {
 	return &WorkerClient{
-		Client:      cws.NewClient(c),
-		ServerID:    serverID,
-		Address:     address,
-		IsAvailable: true,
+		Client:         cws.NewClient(c),
+		ServerID:       serverID,
+		Address:        address,
+		StunTurnServer: stunturn,
+		IsAvailable:    true,
 	}
 }

--- a/overlord/worker.go
+++ b/overlord/worker.go
@@ -1,7 +1,6 @@
 package overlord
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/giongto35/cloud-game/cws"
@@ -45,7 +44,6 @@ func (o *Server) RouteWorker(workerClient *WorkerClient) {
 
 // NewWorkerClient returns a client connecting to worker. This connection exchanges information between workers and server
 func NewWorkerClient(c *websocket.Conn, serverID string, address string, stunturn string) *WorkerClient {
-	fmt.Println("STUN TURN WORKER", stunturn)
 	return &WorkerClient{
 		Client:         cws.NewClient(c),
 		ServerID:       serverID,

--- a/static/js/ws.js
+++ b/static/js/ws.js
@@ -151,12 +151,7 @@ function sendPing() {
 function startWebRTC(iceservers) {
     log(`received stunturn from worker ${iceservers}`)
     // webrtc
-    //var iceservers = [];
-    //if (STUNTURN == "") {
-        //iceservers = defaultICE
-    //} else {
     iceservers = JSON.parse(iceservers);
-    //}
     pc = new RTCPeerConnection({iceServers: iceservers });
 
     // input channel, ordered + reliable, id 0

--- a/static/js/ws.js
+++ b/static/js/ws.js
@@ -24,10 +24,17 @@ conn.onmessage = e => {
     d = JSON.parse(e.data);
     switch (d["id"]) {
 
-    case "gamelist":
-        // parse files list to gamelist
-        files = JSON.parse(d["data"]);
+    case "init":
+        // TODO: Read from struct
+        // init package has 2 part [stunturn, gamelist]
+        // The first element is stunturn address
+        // The rest are list of game
+        data = JSON.parse(d["data"]);
+        stunturn = data[0]
+        startWebRTC(stunturn);
+        data.shift()
         gameList = [];
+
         files.forEach(file => {
             var file = file
             var name = file.substr(0, file.indexOf('.'));
@@ -102,8 +109,8 @@ conn.onmessage = e => {
                     console.log(latenciesMap)
 
                     conn.send(JSON.stringify({"id": "checkLatency", "data": JSON.stringify(latenciesMap), "packet_id": latencyPacketID}));
-                    startWebRTC();
-        }
+                    //startWebRTC();
+                }
             }
             xmlHttp.onload = () => {
                 cntResp++;
@@ -116,8 +123,8 @@ conn.onmessage = e => {
 
                     //conn.send(JSON.stringify({"id": "checkLatency", "data": latenciesMap, "packet_id": latencyPacketID}));
                     conn.send(JSON.stringify({"id": "checkLatency", "data": JSON.stringify(latenciesMap), "packet_id": latencyPacketID}));
-                    startWebRTC();
-        }
+                    //startWebRTC();
+                }
             }
             xmlHttp.send( null );
         }
@@ -141,14 +148,15 @@ function sendPing() {
     conn.send(JSON.stringify({"id": "heartbeat", "data": Date.now().toString()}));
 }
 
-function startWebRTC() {
+function startWebRTC(iceservers) {
+    log("received stunturn from worker ${iceservers}")
     // webrtc
-    var iceservers = [];
-    if (STUNTURN == "") {
-        iceservers = defaultICE
-    } else {
-        iceservers = JSON.parse(STUNTURN);
-    }
+    //var iceservers = [];
+    //if (STUNTURN == "") {
+        //iceservers = defaultICE
+    //} else {
+    iceservers = JSON.parse(STUNTURN);
+    //}
     pc = new RTCPeerConnection({iceServers: iceservers });
 
     // input channel, ordered + reliable, id 0

--- a/static/js/ws.js
+++ b/static/js/ws.js
@@ -35,7 +35,7 @@ conn.onmessage = e => {
         data.shift()
         gameList = [];
 
-        files.forEach(file => {
+        data.forEach(file => {
             var file = file
             var name = file.substr(0, file.indexOf('.'));
             gameList.push({file: file, name: name});
@@ -149,13 +149,13 @@ function sendPing() {
 }
 
 function startWebRTC(iceservers) {
-    log("received stunturn from worker ${iceservers}")
+    log(`received stunturn from worker ${iceservers}`)
     // webrtc
     //var iceservers = [];
     //if (STUNTURN == "") {
         //iceservers = defaultICE
     //} else {
-    iceservers = JSON.parse(STUNTURN);
+    iceservers = JSON.parse(iceservers);
     //}
     pc = new RTCPeerConnection({iceServers: iceservers });
 


### PR DESCRIPTION
In production, CoTurn will be run on the worker directly and worker will use that stun server along with google STUN server.
I don't know if it's a good decision, but it helps me in this case because if user uses TURN, the relay traffic is closer to user. It also helps cut the cost of hosting other server.
Normally in p2p, TURN server is separated but in this case, one of the peers is hosted on server, so we can leave TURN server in the same host as peer. 