### PR TITLE
Fix GBA tearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This project aims to experiment Cloud-gaming performance with [WebRTC](https://g
 
 \*In ideal network condition and less resource contention on servers, the game will run smoothly as in the video demo. Because I only hosted the platform on limited servers in US East, US West, Eu, Singapore, you may experience some latency issues + connection problem. You can try hosting the service following the instruction the next section to have a better sense of performance.  
 
-Screenshot | Screenshot
-:-------------------------:|:-------------------------:
-![screenshot](docs/img/landing-page-ps-hm.png)|![screenshot](docs/img/landing-page-ps-x4.png)
-![screenshot](docs/img/landing-page-gb.png)|![screenshot](docs/img/landing-page-front.png)
+|                   Screenshot                   |                   Screenshot                   |
+| :--------------------------------------------: | :--------------------------------------------: |
+| ![screenshot](docs/img/landing-page-ps-hm.png) | ![screenshot](docs/img/landing-page-ps-x4.png) |
+|  ![screenshot](docs/img/landing-page-gb.png)   | ![screenshot](docs/img/landing-page-front.png) |
 
 ## Feature
 1. Cloud gaming: Game logic and storage is hosted on cloud service. It reduces the cumbersome of game initialization. Images and audio are streamed to user in the most optimal way using advanced encoding technology.
@@ -33,6 +33,16 @@ You try running the server directly by `make dev.run-docker`. It will spawn a do
 
 Install Golang https://golang.org/doc/install . Because the project uses GoModule, so it requires Go1.11 version.
 
+(Optional) Setup MSYS2 (MinGW) environment if you are using Windows:
+  * Please refer to the Libretro [doc](https://docs.libretro.com/development/retroarch/compilation/windows/#environment-configuration) for initial environment setup
+  * Add Golang installation path into your .bashrc
+    ```
+    $ echo 'export PATH=/c/Go/bin:$PATH' >> ~/.bashrc
+    ```
+  * Install dependencies as described down bellow
+  * Copy required [Libretro Core DLLs](http://buildbot.libretro.com/nightly/windows/x86_64/) into the `cloud-game\assets\emulator\libretro\cores` folder and replace existing Linux SOs in the `cloud-game\pkg\config\config.go` EmulatorConfig object.
+  * Use `C:\msys64\mingw64.exe` for building
+
 Install dependencies  
 
   * Install [libvpx](https://www.webmproject.org/code/), [libopus](http://opus-codec.org/), [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
@@ -43,8 +53,8 @@ apt-get install -y pkg-config libvpx-dev libopus-dev libopusfile-dev
 # MacOS
 brew install libvpx pkg-config opus opusfile
 
-# Windows
-... not tested yet ...
+# Windows (MSYS2)
+pacman -S --noconfirm --needed git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn mingw-w64-x86_64-libvpx mingw-w64-x86_64-opusfile
 ```
 
 Because the coordinator and workers need to run simultaneously. Workers connect to the coordinator.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,8 +47,8 @@ type EmulatorMeta struct {
 var EmulatorConfig = map[string]EmulatorMeta{
 	"gba": {
 		Path:   "assets/emulator/libretro/cores/mgba_libretro.so",
-		Width:  240,
-		Height: 160,
+		Width:  160,
+		Height: 144,
 	},
 	"pcsx": {
 		Path:   "assets/emulator/libretro/cores/mednafen_psx_libretro.so",

--- a/pkg/emulator/libretro/nanoarch/nanoarch.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch.go
@@ -196,7 +196,7 @@ func to565Image(data unsafe.Pointer, bytes []byte, bytesPerRow int, inputWidth, 
 				g8 := (g6*255 + 31) / 63
 				r8 := (r5*255 + 15) / 31
 
-				outputImg.Set(int(float64(xx)*scaleWidth), int(float64(yy)*scaleHeight), color.RGBA{byte(r8), byte(g8), byte(b8), 255})
+				outputImg.Set(xx, yy, color.RGBA{byte(r8), byte(g8), byte(b8), 255})
 			}
 
 			seek += 2
@@ -441,6 +441,23 @@ func coreLoadGame(filename string) {
 	avi := C.struct_retro_system_av_info{}
 
 	C.bridge_retro_get_system_av_info(retroGetSystemAVInfo, &avi)
+
+	fmt.Println("-----------------------------------")
+	fmt.Println("--- System audio and video info ---")
+	fmt.Println("-----------------------------------")
+	fmt.Println("  Aspect ratio: ", avi.geometry.aspect_ratio)
+	/* Nominal aspect ratio of game. If
+	* aspect_ratio is <= 0.0, an aspect ratio
+	* of base_width / base_height is assumed.
+	* A frontend could override this setting,
+	* if desired. */
+	fmt.Println("  Base width: ", avi.geometry.base_width)   /* Nominal video width of game. */
+	fmt.Println("  Base height: ", avi.geometry.base_height) /* Nominal video height of game. */
+	fmt.Println("  Max width: ", avi.geometry.max_width)     /* Maximum possible width of game. */
+	fmt.Println("  Max height: ", avi.geometry.max_height)   /* Maximum possible height of game. */
+	fmt.Println("  Sample rate: ", avi.timing.sample_rate)   /* Sampling rate of audio. */
+	fmt.Println("  FPS: ", avi.timing.fps)                   /* FPS of video content. */
+	fmt.Println("-----------------------------------")
 
 	// Append the library name to the window title.
 	NAEmulator.meta.AudioSampleRate = int(avi.timing.sample_rate)


### PR DESCRIPTION
Just a "quick" fix to the GBA 565 -> RGBA conversion.
Someone scaled game frame pixels twice and the config fog GBA seems wrong. At least, you can play GBC Yu-gi-oh now.

Before
![image](https://user-images.githubusercontent.com/846874/66408538-cbfc1500-e9f7-11e9-9e4f-0973b4018e58.png)

After
![image](https://user-images.githubusercontent.com/846874/66408566-dae2c780-e9f7-11e9-9c3c-dd34f1a5f673.png)

Maybe you are aware, that there is a problem with all that image scaling which I will describe in another ticket. In some cases on different cores and ROMs it is possible to have the same bug (PSX BIOS logo intro as example).