### PR TITLE
Unblock sending audio channel

### DIFF
--- a/pkg/emulator/libretro/nanoarch/nanoarch.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch.go
@@ -136,7 +136,10 @@ func audioWrite2(buf unsafe.Pointer, frames C.size_t) C.size_t {
 	// copy because pcm slice refer to buf underlying pointer, and buf pointer is the same in continuos frames
 	copy(p, pcm)
 
-	NAEmulator.audioChannel <- p
+	select {
+	case NAEmulator.audioChannel <- p:
+	default:
+	}
 
 	return frames
 }


### PR DESCRIPTION
Some deadlock is still happening, causing the app hanging. I think better reuse non-block sending audio first to check if it's really the issue.
I think the audio quality won't get affected much. 