### PR TITLE
Close room signal overlord

### DIFF
--- a/pkg/overlord/worker.go
+++ b/pkg/overlord/worker.go
@@ -17,13 +17,26 @@ type WorkerClient struct {
 
 // RouteWorker are all routes server received from worker
 func (o *Server) RouteWorker(workerClient *WorkerClient) {
-	// registerRoom event from a server, when server created a new room.
+	// registerRoom event from a worker, when worker created a new room.
 	// RoomID is global so it is managed by overlord.
 	workerClient.Receive("registerRoom", func(resp cws.WSPacket) cws.WSPacket {
-		log.Println("Overlord: Received registerRoom ", resp.Data, workerClient.ServerID)
+		log.Printf("Overlord: Received registerRoom room %s from worker %s", resp.Data, workerClient.ServerID)
 		o.roomToServer[resp.Data] = workerClient.ServerID
+		log.Printf("Overlord: Current room list is: %+v", o.roomToServer)
+
 		return cws.WSPacket{
 			ID: "registerRoom",
+		}
+	})
+
+	// closeRoom event from a worker, when worker close a room
+	workerClient.Receive("closeRoom", func(resp cws.WSPacket) cws.WSPacket {
+		log.Printf("Overlord: Received closeRoom room %s from worker %s", resp.Data, workerClient.ServerID)
+		delete(o.roomToServer, resp.Data)
+		log.Printf("Overlord: Current room list is: %+v", o.roomToServer)
+
+		return cws.WSPacket{
+			ID: "closeRoom",
 		}
 	})
 

--- a/pkg/worker/overlord.go
+++ b/pkg/worker/overlord.go
@@ -229,6 +229,11 @@ func (h *Handler) startGameHandler(gameName, roomID string, playerIndex int, pee
 		go func() {
 			<-room.Done
 			h.detachRoom(room.ID)
+			// send signal to overlord that the room is closed, overlord will remove that room
+			h.oClient.Send(cws.WSPacket{
+				ID:   "closeRoom",
+				Data: roomID,
+			}, nil)
 		}()
 	}
 


### PR DESCRIPTION
RoomToServer storing a map from room to server in Overlord. Currently, when the room ends in worker, it should signal overlord to delete this mapping.
The bug is causing the situation when user keep joining the ended room in a server