### PR TITLE
Refactor: Fix channel init order

### DIFF
--- a/pkg/encoder/h264encoder/encoder.go
+++ b/pkg/encoder/h264encoder/encoder.go
@@ -130,6 +130,7 @@ func (v *H264Encoder) GetOutputChan() chan []byte {
 
 // GetDoneChan returns done channel
 func (v *H264Encoder) Stop() {
-	v.Done = true
-	close(v.Input)
+	//v.Done = true
+	//close(v.Input)
+	v.release()
 }

--- a/pkg/encoder/h264encoder/encoder.go
+++ b/pkg/encoder/h264encoder/encoder.go
@@ -21,7 +21,6 @@ type H264Encoder struct {
 	enc *x264.Encoder
 
 	IsRunning bool
-	Done      bool
 	// C
 	width  int
 	height int
@@ -35,7 +34,6 @@ func NewH264Encoder(width, height, fps int) (encoder.Encoder, error) {
 		Input:  make(chan *image.RGBA, chanSize),
 
 		IsRunning: true,
-		Done:      false,
 
 		buf:    bytes.NewBuffer(make([]byte, 0)),
 		width:  width,
@@ -79,21 +77,9 @@ func (v *H264Encoder) startLooping() {
 			log.Println("Warn: Recovered panic in encoding ", r)
 			log.Println(debug.Stack())
 		}
-
-		if v.Done == true {
-			// The first time we see IsRunning set to false, we release and return
-			v.release()
-			return
-		}
 	}()
 
 	for img := range v.Input {
-		if v.Done == true {
-			// The first time we see IsRunning set to false, we release and return
-			v.release()
-			return
-		}
-
 		err := v.enc.Encode(img)
 		if err != nil {
 			log.Println("err encoding ", img, " using h264")
@@ -130,7 +116,5 @@ func (v *H264Encoder) GetOutputChan() chan []byte {
 
 // GetDoneChan returns done channel
 func (v *H264Encoder) Stop() {
-	//v.Done = true
-	//close(v.Input)
 	v.release()
 }

--- a/pkg/encoder/h264encoder/encoder.go
+++ b/pkg/encoder/h264encoder/encoder.go
@@ -20,7 +20,6 @@ type H264Encoder struct {
 	buf *bytes.Buffer
 	enc *x264.Encoder
 
-	IsRunning bool
 	// C
 	width  int
 	height int
@@ -32,8 +31,6 @@ func NewH264Encoder(width, height, fps int) (encoder.Encoder, error) {
 	v := &H264Encoder{
 		Output: make(chan []byte, 5*chanSize),
 		Input:  make(chan *image.RGBA, chanSize),
-
-		IsRunning: true,
 
 		buf:    bytes.NewBuffer(make([]byte, 0)),
 		width:  width,
@@ -49,8 +46,6 @@ func NewH264Encoder(width, height, fps int) (encoder.Encoder, error) {
 }
 
 func (v *H264Encoder) init() error {
-	v.IsRunning = true
-
 	opts := &x264.Options{
 		Width:     v.width,
 		Height:    v.height,
@@ -91,17 +86,13 @@ func (v *H264Encoder) startLooping() {
 
 // Release release memory and stop loop
 func (v *H264Encoder) release() {
-	if v.IsRunning {
-		v.IsRunning = false
-		log.Println("Releasing encoder")
-		// TODO: Bug here, after close it will signal
-		close(v.Output)
-		err := v.enc.Close()
-		if err != nil {
-			log.Println("Failed to close H264 encoder")
-		}
+	log.Println("Releasing encoder")
+	// TODO: Bug here, after close it will signal
+	close(v.Output)
+	err := v.enc.Close()
+	if err != nil {
+		log.Println("Failed to close H264 encoder")
 	}
-	// TODO: Can we merge IsRunning and Done together
 }
 
 // GetInputChan returns input channel


### PR DESCRIPTION
Follow Golang convention:
Writer close channel,
Emulator produces image and audio  => Emulator is the owner of image channel and audio channel, Emulator will initialize Image Channel and Audio Channel on its side.
Room will close Encoder Channel when image stream finishes
