### PR TITLE
Fix deadlock

### DIFF
--- a/pkg/emulator/libretro/nanoarch/naemulator.go
+++ b/pkg/emulator/libretro/nanoarch/naemulator.go
@@ -3,6 +3,7 @@ package nanoarch
 import (
 	"image"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/giongto35/cloud-game/pkg/config"
@@ -59,6 +60,9 @@ type naEmulator struct {
 
 	keys []bool
 	done chan struct{}
+
+	// lock to lock uninteruptable operation
+	lock *sync.Mutex
 }
 
 var NAEmulator *naEmulator
@@ -78,6 +82,7 @@ func NewNAEmulator(etype string, roomID string, inputChannel <-chan int) (*naEmu
 		keys:         make([]bool, joypadNumKeys),
 		roomID:       roomID,
 		done:         make(chan struct{}, 1),
+		lock:         &sync.Mutex{},
 	}, imageChannel, audioChannel
 }
 

--- a/pkg/emulator/libretro/nanoarch/savestates.go
+++ b/pkg/emulator/libretro/nanoarch/savestates.go
@@ -18,20 +18,16 @@ import "C"
 
 import (
 	"io/ioutil"
-	"sync"
 )
 
-var saveLock int32
-var m sync.Mutex
-
 func (na *naEmulator) GetLock() {
-	//atomic.CompareAndSwapInt32(&saveLock, 0, 1)
-	m.Lock()
+	//atomic.CompareAndSwapInt32(&na.saveLock, 0, 1)
+	na.lock.Lock()
 }
 
 func (na *naEmulator) ReleaseLock() {
-	//atomic.CompareAndSwapInt32(&saveLock, 1, 0)
-	m.Unlock()
+	//atomic.CompareAndSwapInt32(&na.saveLock, 1, 0)
+	na.lock.Unlock()
 }
 
 // Save the current state to the filesystem. name is the name of the


### PR DESCRIPTION
There is an emulator lock using in **Save Operation**, **Load Operation** and **Game Update**. This is causing deadlock when room closes acquiring lock, save operation triggered in the middle attempts to acquire the same lock and hang.
Use async for Save Operation to avoid that