### PR TITLE
Fix pprof path

### DIFF
--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -60,6 +60,14 @@ func (sm *ServerMonitoring) Run() error {
 			monitoringServerMux.Handle(pprofPath+"/profile", http.HandlerFunc(pprof.Profile))
 			monitoringServerMux.Handle(pprofPath+"/symbol", http.HandlerFunc(pprof.Symbol))
 			monitoringServerMux.Handle(pprofPath+"/trace", http.HandlerFunc(pprof.Trace))
+			// pprof handler for custom pprof path needs to be explicitly specified, according to: https://github.com/gin-contrib/pprof/issues/8 . Don't know why this is not fired as ticket
+			// https://golang.org/src/net/http/pprof/pprof.go?s=7411:7461#L305 only render index page
+			monitoringServerMux.Handle(pprofPath+"/allocs", pprof.Handler("allocs"))
+			monitoringServerMux.Handle(pprofPath+"/block", pprof.Handler("block"))
+			monitoringServerMux.Handle(pprofPath+"/goroutine", pprof.Handler("goroutine"))
+			monitoringServerMux.Handle(pprofPath+"/heap", pprof.Handler("heap"))
+			monitoringServerMux.Handle(pprofPath+"/mutex", pprof.Handler("mutex"))
+			monitoringServerMux.Handle(pprofPath+"/threadcreate", pprof.Handler("threadcreate"))
 		}
 
 		if sm.cfg.MetricEnabled {


### PR DESCRIPTION
@sadlil  Just figured out an issue with pprof. When we create custom pprof URL `worker/debug/pprof/` as you do instead of the original `/debug/pprof/`, the access to goroutine, allocs profile ... gets 404. i.e `http://localhost:6601/worker/debug/pprof/goroutine?debug=1`
The issue is described better in:
https://github.com/gin-contrib/pprof/issues/8
The solution is to declare all the path explicitly.
I don't think this is expected from pprof side. Can this issue be fired as ticket to them?

How to reproduce:
1) go run cmd/worker/main.go -p
2) go run cmd/coordinator/main.go
3) open `http://localhost:6601/worker/debug/pprof/`.
4) click goroutine => doesn't show anything