### PR TITLE
Add Github Docker repo publisher

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------------------
+#  Publish Docker image from the current snapshot into Github repository
+# ------------------------------------------------------------------------
+
+name: publish
+# run only when pushing into the master, tagged with a v-prefix
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+jobs:
+  docker-publish:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the source
+        uses: actions/checkout@v2
+      - name: Publish to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          add_git_labels: true
+          tag_with_ref: true
+          username: ${{ github.ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: giongto35/cloud-game/cloud-game


### PR DESCRIPTION
Added gh Docker repo publish. Build from Dockerfile.
Should look like [this](https://github.com/sergystepanov/cloud-game/packages/261228).
You can pull them as described there and add own custom stuff.

When you push either to master or tag anything with v-prefixed tag, it will build and publish new Docker image. An image with `latest` tag will be replaced by new master source, v-something will be a build from v-prefixed source.

Sha-tagged images can be used as well but I don't think they are useful, so I won't be using them.