### PR TITLE
Add basic N64 support on Mac

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,15 +7,15 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/faiface/mainthread"
 	config "github.com/giongto35/cloud-game/pkg/config/worker"
-
 	"github.com/giongto35/cloud-game/pkg/util/logging"
 	"github.com/giongto35/cloud-game/pkg/worker"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 )
 
-func main() {
+func run() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	cfg := config.NewDefaultConfig()
@@ -42,4 +42,9 @@ func main() {
 		o.Shutdown()
 		cancelCtx()
 	}
+}
+
+func main() {
+	// enables mainthread package and runs run in a separate goroutine
+	mainthread.Run(run)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	cloud.google.com/go v0.43.0
 	github.com/disintegration/imaging v1.6.2
+	github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3
 	github.com/gen2brain/x264-go v0.0.0-20200517120223-c08131f6fc8a
 	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3 h1:baVdMKlASEHrj19iqjARrPbaRisD7EuZEVJj6ZMLl1Q=
+github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3/go.mod h1:VEPNJUlxl5KdWjDvz6Q1l+rJlxF2i6xqDeGuGAxa87M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gen2brain/x264-go v0.0.0-20200517120223-c08131f6fc8a h1:O6MN0Yik9iXHlC5t/NUznAgt18d0yAKIPZTihxLBIDE=


### PR DESCRIPTION
Note: mupen64plus lib unload is not working properly on Mac, so stopping and restarting N64 emulation will cause a crash