### PR TITLE
Add frame delay or frame rate stats to stat view.

### DIFF
--- a/web/js/network/rtcp.js
+++ b/web/js/network/rtcp.js
@@ -176,6 +176,7 @@ const rtcp = (() => {
         },
         input: (data) => inputChannel.send(data),
         isConnected: () => connected,
-        isInputReady: () => inputReady
+        isInputReady: () => inputReady,
+        getConnection: () => connection,
     }
 })(event, socket, env, log);


### PR DESCRIPTION
Unfortunately Firefox does not expose frame delay stat.
Unfortunately Chrome and Safari do not expose frame rate stat.