### PR TITLE
Add HTTP port config for Coordinator and Worker

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,10 +15,10 @@ const AUDIO_CHANNELS = 2
 const AUDIO_MS = 20
 const AUDIO_FRAME = AUDIO_RATE * AUDIO_MS / 1000 * AUDIO_CHANNELS
 
-var Port = flag.String("port", "8000", "Port of the game")
 var FrontendSTUNTURN = flag.String("stunturn", DefaultSTUNTURN, "Frontend STUN TURN servers")
 var Mode = flag.String("mode", "dev", "Environment")
 var StunTurnTemplate = `[{"urls":"stun:stun.l.google.com:19302"},{"urls":"stun:%s:3478"},{"urls":"turn:%s:3478","username":"root","credential":"root"}]`
+var HttpPort = flag.String("httpPort", "8000", "User agent port of the app")
 var HttpsPort = flag.Int("httpsPort", 443, "Https Port")
 var HttpsKey = flag.String("httpsKey", "", "Https Key")
 var HttpsChain = flag.String("httpsChain", "", "Https Chain")

--- a/pkg/config/worker/config.go
+++ b/pkg/config/worker/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	Port               int
 	CoordinatorAddress string
+	HttpPort           int
 
 	// video
 	Scale             int
@@ -23,6 +24,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		Port:               8800,
 		CoordinatorAddress: "localhost:8000",
+		HttpPort:           9000,
 		Scale:              1,
 		EnableAspectRatio:  false,
 		Width:              320,
@@ -39,6 +41,7 @@ func NewDefaultConfig() Config {
 func (c *Config) AddFlags(fs *pflag.FlagSet) *Config {
 	fs.IntVarP(&c.Port, "port", "", 8800, "Worker server port")
 	fs.StringVarP(&c.CoordinatorAddress, "coordinatorhost", "", c.CoordinatorAddress, "Worker URL to connect")
+	fs.IntVarP(&c.HttpPort, "httpPort", "", c.HttpPort, "Set external HTTP port")
 	fs.StringVarP(&c.Zone, "zone", "z", c.Zone, "Zone of the worker")
 
 	fs.IntVarP(&c.Scale, "scale", "s", c.Scale, "Set output viewport scale factor")

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -146,7 +146,7 @@ func (o *Coordinator) initializeCoordinator() {
 		httpSrv.Handler = certManager.HTTPHandler(httpSrv.Handler)
 	}
 
-	httpSrv.Addr = ":8000"
+	httpSrv.Addr = ":" + *config.HttpPort
 	err := httpSrv.ListenAndServe()
 	if err != nil {
 		log.Fatalf("httpSrv.ListenAndServe() failed with %s", err)

--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -121,6 +121,8 @@ func (o *Server) WSO(w http.ResponseWriter, r *http.Request) {
 
 	pingServer := o.getPingServer(zone)
 
+	wc.Printf("Set ping server address: %s", pingServer)
+
 	// In case worker and coordinator in the same host
 	if !util.IsPublicIP(address) && *config.Mode == config.ProdEnv {
 		// Don't accept private IP for worker's address in prod mode

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -157,14 +157,16 @@ func (o *Worker) initializeWorker() {
 	port := o.cfg.HttpPort
 	// It's recommend to run one worker on one instance.
 	// This logic is to make sure more than 1 workers still work
+	portsNum := 100
 	for {
+		portsNum--
 		l, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 		if err != nil {
 			port++
 			continue
 		}
 
-		if l == nil {
+		if portsNum < 1 {
 			log.Printf("Couldn't find an open port in range %v-%v\n", o.cfg.HttpPort, port)
 			// Cannot find port
 			return

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -109,9 +109,9 @@ func (o *Worker) spawnServer(port int) {
 			}
 
 			certManager = &autocert.Manager{
-				Prompt:     autocert.AcceptTOS,
-				Cache:      autocert.DirCache("assets/cache"),
-				Client:     &acme.Client{DirectoryURL: leurl},
+				Prompt: autocert.AcceptTOS,
+				Cache:  autocert.DirCache("assets/cache"),
+				Client: &acme.Client{DirectoryURL: leurl},
 			}
 
 			httpsSrv.TLSConfig = &tls.Config{GetCertificate: certManager.GetCertificate}
@@ -154,22 +154,23 @@ func (o *Worker) initializeWorker() {
 	}()
 
 	go worker.Run()
-	port := 9000
-	// It's recommend to run one worker on one instance. This logic is to make sure more than 1 workers still work
+	port := o.cfg.HttpPort
+	// It's recommend to run one worker on one instance.
+	// This logic is to make sure more than 1 workers still work
 	for {
-		log.Println("Listening at port: localhost:", port)
-		// err := http.ListenAndServe(":"+strconv.Itoa(port), nil)
 		l, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 		if err != nil {
 			port++
 			continue
 		}
-		if port == 9100 {
+
+		if l == nil {
+			log.Printf("Couldn't find an open port in range %v-%v\n", o.cfg.HttpPort, port)
 			// Cannot find port
 			return
 		}
 
-		l.Close()
+		_ = l.Close()
 
 		o.spawnServer(port)
 	}


### PR DESCRIPTION
It is possible to config HTTP ports for both apps with --httpPort flag.