### PR TITLE
Free save state buffer from malloc

### DIFF
--- a/pkg/emulator/libretro/nanoarch/nanoarch.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch.go
@@ -653,13 +653,16 @@ func serializeSize() uint {
 	return uint(C.bridge_retro_serialize_size(retroSerializeSize))
 }
 
-// serialize serializes internal state and returns the state as a byte slice.
+// Serializes internal state and returns the state as a byte slice.
 func serialize(size uint) ([]byte, error) {
 	data := C.malloc(C.size_t(size))
+	defer C.free(data)
+
 	ok := bool(C.bridge_retro_serialize(retroSerialize, data, C.size_t(size)))
 	if !ok {
 		return nil, errors.New("retro_serialize failed")
 	}
+
 	bytes := C.GoBytes(data, C.int(size))
 	return bytes, nil
 }


### PR DESCRIPTION
While working on save states, found that we are using one hugely leaking `malloc` function for save state buffering.

https://github.com/giongto35/cloud-game/blob/c23347db0814856ae07e5649886d3d340305d08a/pkg/emulator/libretro/nanoarch/nanoarch.go#L656-L665

The later call of `C.GoBytes` makes a copy of `data`.
Here some test before and after on PSX with 4Mb save states.
Made the PR, because I think, this fix is kinda critical.
Also there are some unidentified leaks still present.

Mashing the save. Memory `never` recovers.

![before](https://user-images.githubusercontent.com/846874/85852716-d5adee80-b7b9-11ea-9be0-f19771479708.gif)

Mashing the save. Memory recovers.

![before2](https://user-images.githubusercontent.com/846874/85853220-ced3ab80-b7ba-11ea-8277-e30b7246001b.gif)

Forgot to mention that Libretro cores can change save state size (shrink) dynamically. It's not an issue atm, but if we ever change the current code to fixed max save state buffer length calculated only on the game load, then we may have some problems with malloc's garbage in the buffer. Retroarch uses zeroed calloc buffers for that reason. Just keep it in mind. (:



