### PR TITLE
Explicitly set RTP timestamp to cope with variable frame rate.

### DIFF
--- a/pkg/emulator/libretro/nanoarch/naemulator.go
+++ b/pkg/emulator/libretro/nanoarch/naemulator.go
@@ -55,7 +55,7 @@ type constrollerState struct {
 
 // naEmulator implements CloudEmulator
 type naEmulator struct {
-	imageChannel chan<- *image.RGBA
+	imageChannel chan<- GameFrame
 	audioChannel chan<- []int16
 	inputChannel <-chan InputEvent
 
@@ -78,15 +78,20 @@ type InputEvent struct {
 	ConnID    string
 }
 
+type GameFrame struct {
+	Image     *image.RGBA
+	Timestamp uint32
+}
+
 var NAEmulator *naEmulator
 var outputImg *image.RGBA
 
 const maxPort = 8
 
 // NAEmulator implements CloudEmulator interface based on NanoArch(golang RetroArch)
-func NewNAEmulator(etype string, roomID string, inputChannel <-chan InputEvent) (*naEmulator, chan *image.RGBA, chan []int16) {
+func NewNAEmulator(etype string, roomID string, inputChannel <-chan InputEvent) (*naEmulator, chan GameFrame, chan []int16) {
 	meta := config.EmulatorConfig[etype]
-	imageChannel := make(chan *image.RGBA, 30)
+	imageChannel := make(chan GameFrame, 30)
 	audioChannel := make(chan []int16, 30)
 
 	return &naEmulator{
@@ -102,7 +107,7 @@ func NewNAEmulator(etype string, roomID string, inputChannel <-chan InputEvent) 
 }
 
 // Init initialize new RetroArch cloud emulator
-func Init(etype string, roomID string, inputChannel <-chan InputEvent) (*naEmulator, chan *image.RGBA, chan []int16) {
+func Init(etype string, roomID string, inputChannel <-chan InputEvent) (*naEmulator, chan GameFrame, chan []int16) {
 	emulator, imageChannel, audioChannel := NewNAEmulator(etype, roomID, inputChannel)
 	// Set to global NAEmulator
 	NAEmulator = emulator

--- a/pkg/encoder/h264encoder/encoder.go
+++ b/pkg/encoder/h264encoder/encoder.go
@@ -2,7 +2,6 @@ package h264encoder
 
 import (
 	"bytes"
-	"image"
 	"log"
 	"runtime/debug"
 
@@ -14,8 +13,8 @@ const chanSize = 2
 
 // H264Encoder yuvI420 image to vp8 video
 type H264Encoder struct {
-	Output chan []byte      // frame
-	Input  chan *image.RGBA // yuvI420
+	Output chan encoder.OutFrame
+	Input  chan encoder.InFrame
 
 	buf *bytes.Buffer
 	enc *x264.Encoder
@@ -29,8 +28,8 @@ type H264Encoder struct {
 // NewH264Encoder create h264 encoder
 func NewH264Encoder(width, height, fps int) (encoder.Encoder, error) {
 	v := &H264Encoder{
-		Output: make(chan []byte, 5*chanSize),
-		Input:  make(chan *image.RGBA, chanSize),
+		Output: make(chan encoder.OutFrame, 5*chanSize),
+		Input:  make(chan encoder.InFrame,    chanSize),
 
 		buf:    bytes.NewBuffer(make([]byte, 0)),
 		width:  width,
@@ -75,11 +74,11 @@ func (v *H264Encoder) startLooping() {
 	}()
 
 	for img := range v.Input {
-		err := v.enc.Encode(img)
+		err := v.enc.Encode(img.Image)
 		if err != nil {
-			log.Println("err encoding ", img, " using h264")
+			log.Println("err encoding ", img.Image, " using h264")
 		}
-		v.Output <- v.buf.Bytes()
+		v.Output <- encoder.OutFrame{ Data: v.buf.Bytes(), Timestamp: img.Timestamp }
 		v.buf.Reset()
 	}
 }
@@ -96,12 +95,12 @@ func (v *H264Encoder) release() {
 }
 
 // GetInputChan returns input channel
-func (v *H264Encoder) GetInputChan() chan *image.RGBA {
+func (v *H264Encoder) GetInputChan() chan encoder.InFrame {
 	return v.Input
 }
 
 // GetInputChan returns output channel
-func (v *H264Encoder) GetOutputChan() chan []byte {
+func (v *H264Encoder) GetOutputChan() chan encoder.OutFrame {
 	return v.Output
 }
 

--- a/pkg/encoder/type.go
+++ b/pkg/encoder/type.go
@@ -2,8 +2,18 @@ package encoder
 
 import "image"
 
+type InFrame struct {
+	Image     *image.RGBA
+	Timestamp uint32
+}
+
+type OutFrame struct {
+	Data      []byte
+	Timestamp uint32
+}
+
 type Encoder interface {
-	GetInputChan() chan *image.RGBA
-	GetOutputChan() chan []byte
+	GetInputChan()  chan InFrame
+	GetOutputChan() chan OutFrame
 	Stop()
 }

--- a/pkg/worker/room/room.go
+++ b/pkg/worker/room/room.go
@@ -1,7 +1,6 @@
 package room
 
 import (
-	"image"
 	"io/ioutil"
 	"log"
 	"math"
@@ -29,7 +28,7 @@ type Room struct {
 	ID string
 
 	// imageChannel is image stream received from director
-	imageChannel <-chan *image.RGBA
+	imageChannel <-chan nanoarch.GameFrame
 	// audioChannel is audio stream received from director
 	audioChannel <-chan []int16
 	// inputChannel is input stream send to director. This inputChannel is combined
@@ -169,7 +168,7 @@ func resizeToAspect(ratio float64, sw int, sh int) (dw int, dh int) {
 }
 
 // getEmulator creates new emulator and run it
-func getEmulator(emuName string, roomID string, imageChannel chan<- *image.RGBA, audioChannel chan<- []int16, inputChannel <-chan int) emulator.CloudEmulator {
+func getEmulator(emuName string, roomID string, imageChannel chan<- nanoarch.GameFrame, audioChannel chan<- []int16, inputChannel <-chan int) emulator.CloudEmulator {
 
 	return nanoarch.NAEmulator
 }


### PR DESCRIPTION
Set the timestamp as early as possible and propagate it through the pipeline.

This fixes issue #198.
See this Chromium [discussion](https://bugs.chromium.org/p/chromium/issues/detail?id=1098514) for background.

I first tried setting a completely artificial timestamp that would would tick once per coreVideoRefresh call.
That helped for cases where the encoding pipeline drops frames as it cannot keep up with the emulator.
However, it did not help when the emulator itself changes the frame rate because of lack of resources or simply because there is nothing to render.
Therefore I went for a real time based time stamp with a seed (I assume the original code had this to avoid easy to decrypt patterns in an encrypted stream) and with a 120fps resolution.

I tried a bit higher and lower resolutions and settled on this...
I am not sure how much of a difference small variations make so we can keep experimenting on them.
Also we can put this use of a timestamp behind a config flag if we find out it makes things worse for certain games...