### PR TITLE
Fix race condition when closing encoders

### DIFF
--- a/pkg/encoder/h264encoder/encoder.go
+++ b/pkg/encoder/h264encoder/encoder.go
@@ -4,19 +4,18 @@ import (
 	"bytes"
 	"log"
 	"runtime/debug"
-	"sync"
 
 	"github.com/gen2brain/x264-go"
 	"github.com/giongto35/cloud-game/pkg/encoder"
 )
 
 const chanSize = 2
-var mu sync.Mutex
 
 // H264Encoder yuvI420 image to vp8 video
 type H264Encoder struct {
 	Output chan encoder.OutFrame
 	Input  chan encoder.InFrame
+	done   chan struct{}
 
 	buf *bytes.Buffer
 	enc *x264.Encoder
@@ -32,6 +31,7 @@ func NewH264Encoder(width, height, fps int) (encoder.Encoder, error) {
 	v := &H264Encoder{
 		Output: make(chan encoder.OutFrame, 5*chanSize),
 		Input:  make(chan encoder.InFrame,    chanSize),
+		done:   make(chan struct{}),
 
 		buf:    bytes.NewBuffer(make([]byte, 0)),
 		width:  width,
@@ -75,9 +75,6 @@ func (v *H264Encoder) startLooping() {
 		}
 	}()
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	for img := range v.Input {
 		err := v.enc.Encode(img.Image)
 		if err != nil {
@@ -87,12 +84,14 @@ func (v *H264Encoder) startLooping() {
 		v.buf.Reset()
 	}
 	close(v.Output)
+	close(v.done)
 }
 
 // Release release memory and stop loop
 func (v *H264Encoder) release() {
-	mu.Lock()
-	defer mu.Unlock()
+	close(v.Input)
+	// Wait for loop to stop
+	<-v.done
 	log.Println("Releasing encoder")
 	err := v.enc.Close()
 	if err != nil {

--- a/pkg/worker/room/media.go
+++ b/pkg/worker/room/media.go
@@ -138,6 +138,10 @@ func (r *Room) startVideo(width, height int, videoEncoderType string) {
 		enc, err = vpxencoder.NewVpxEncoder(width, height, 20, 1200, 5)
 	}
 
+	defer func() {
+		enc.Stop()
+	}()
+
 	if err != nil {
 		fmt.Println("error create new encoder", err)
 		return
@@ -173,7 +177,4 @@ func (r *Room) startVideo(width, height int, videoEncoderType string) {
 		}
 	}
 	log.Println("Room ", r.ID, " video channel closed")
-	// Order is very important here, the other way around would cause a deadlock
-	close(einput)
-	enc.Stop()
 }


### PR DESCRIPTION
I am applying the principle found [here](https://go101.org/article/channel-closing.html): **don't close a channel from the receiver side and don't close a channel if the channel has multiple concurrent senders**.

Media will now wait for the emulator to gracefully close, and then close the encoder input.
The encoder will wait for media to gracefully close its input, and then close its output and release any memory that cannot be garbage collected.

There are also other channels in the project that could be refactored to follow this principle.
However, they are a bit more complex and more importantly they seem to work, so let's not change it if it ain't broken.

This should fix issue #180.