### PR TITLE
Support of SoX resampler v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/prometheus/procfs v0.3.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/veandco/go-sdl2 v0.4.5
+	github.com/zaf/resample v0.0.0-20200305235742-54008d320155
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6
 	golang.org/x/mod v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zaf/resample v0.0.0-20200305235742-54008d320155 h1:im9eeyCI2kVO40ejKOylKpq9D0aQKVa8WT5JLyfAWPE=
+github.com/zaf/resample v0.0.0-20200305235742-54008d320155/go.mod h1:sGUsP1cM3siGx0Q1BXAo/4CPPz9mlupiVy1MZasc7OQ=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=

--- a/pkg/encoder/opus/encoder.go
+++ b/pkg/encoder/opus/encoder.go
@@ -19,6 +19,7 @@ type Encoder struct {
 	buffer          Buffer
 	onFullBuffer    func(data []byte)
 	resampleBufSize int
+	resampler       Resampler
 }
 
 func NewEncoder(inputSampleRate, outputSampleRate, channels int, options ...func(*Encoder) error) (Encoder, error) {
@@ -37,6 +38,8 @@ func NewEncoder(inputSampleRate, outputSampleRate, channels int, options ...func
 		channels:      channels,
 		inFrequency:   inputSampleRate,
 		outFrequency:  outputSampleRate,
+		resampler:    &Giongto35LinearResampler{},
+		//resampler: &SoxResampler{
 		outBufferSize: 1024,
 		onFullBuffer:  func(data []byte) {},
 	}
@@ -89,8 +92,25 @@ func (e *Encoder) BufferWrite(samples []int16) (written int) {
 
 func (e *Encoder) Encode(pcm []int16) ([]byte, error) {
 	if e.resampleBufSize > 0 {
-		pcm = resampleFn(pcm, e.resampleBufSize)
+		err := e.resampler.Init(e.inFrequency, e.outFrequency)
+		if err != nil {
+			return nil, err
+		}
+		pcm = e.resampler.Resample(pcm, e.resampleBufSize)
+		err = e.resampler.Close()
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	if len(pcm) < e.resampleBufSize {
+		gap := make([]int16, e.resampleBufSize-len(pcm))
+		for i := range gap {
+			gap[i] = pcm[len(pcm)-1]
+		}
+		pcm = append(pcm, gap...)
+	}
+
 	data := make([]byte, e.outBufferSize)
 	n, err := e.Encoder.Encode(pcm, data)
 	if err != nil {
@@ -113,26 +133,8 @@ func (e *Encoder) GetInfo() string {
 	)
 }
 
-// resampleFn does a simple linear interpolation of audio samples.
-func resampleFn(pcm []int16, size int) []int16 {
-	r, l, audio := make([]int16, size/2), make([]int16, size/2), make([]int16, size)
-	// ratio is basically the destination sample rate
-	// divided by the origin sample rate (i.e. 48000/44100)
-	ratio := float32(size) / float32(len(pcm))
-	for i, n := 0, len(pcm)-1; i < n; i += 2 {
-		idx := int(float32(i/2) * ratio)
-		r[idx], l[idx] = pcm[i], pcm[i+1]
-	}
-	for i, n := 1, len(r); i < n; i++ {
-		if r[i] == 0 {
-			r[i] = r[i-1]
-		}
-		if l[i] == 0 {
-			l[i] = l[i-1]
-		}
-	}
-	for i := 0; i < size-1; i += 2 {
-		audio[i], audio[i+1] = r[i/2], l[i/2]
-	}
-	return audio
+// Close cleanups external resources for encoders.
+// ! OPUS lib wrapper doesn't have proper close function.
+func (e *Encoder) Close() {
+	_ = e.resampler.Close()
 }

--- a/pkg/encoder/opus/encoder_test.go
+++ b/pkg/encoder/opus/encoder_test.go
@@ -10,18 +10,23 @@ var resampleData []int16
 
 func init() {
 	rand.Seed(time.Now().Unix())
-	l := rand.Perm(getBufferLength(44000))
+	l := rand.Perm(getBufferLength(32768))
 	for _, n := range l {
 		resampleData = append(resampleData, int16(n))
 	}
 }
 
 func BenchmarkResample(b *testing.B) {
-	sr := 48000
-	bs := getBufferLength(sr)
+	//sr := 48000
+	//bs := getBufferLength(sr)
+	resampler := SoxResampler{
+	}
 	for i := 0; i < b.N; i++ {
-		resampleFn(resampleData, bs)
+		resampler.Init(32768, 48000)
+		pcm := resampler.Resample(resampleData, 48000/1000*1*2)
+		b.Logf("Written: %v", len(pcm))
+		resampler.backend.Close()
 	}
 }
 
-func getBufferLength(sampleRate int) int { return sampleRate * 20 / 1000 * 2 }
+func getBufferLength(sampleRate int) int { return sampleRate / 1000 * 1 * 2 }

--- a/pkg/encoder/opus/resampler.go
+++ b/pkg/encoder/opus/resampler.go
@@ -1,0 +1,97 @@
+package opus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/zaf/resample"
+	"log"
+)
+
+type Resampler interface {
+	Init(in, out int) error
+	Resample(pcm []int16, size int) []int16
+	Close() error
+}
+
+type (
+	Giongto35LinearResampler struct{}
+	SoxResampler             struct {
+		backend resample.Resampler
+		buffer  *bytes.Buffer
+	}
+)
+
+// resampleFn does a simple linear interpolation of audio samples.
+func (Giongto35LinearResampler) Resample(pcm []int16, size int) []int16 {
+	r, l, audio := make([]int16, size/2), make([]int16, size/2), make([]int16, size)
+	// ratio is basically the destination sample rate
+	// divided by the origin sample rate (i.e. 48000/44100)
+	ratio := float32(size) / float32(len(pcm))
+	for i, n := 0, len(pcm)-1; i < n; i += 2 {
+		idx := int(float32(i/2) * ratio)
+		r[idx], l[idx] = pcm[i], pcm[i+1]
+	}
+	for i, n := 1, len(r); i < n; i++ {
+		if r[i] == 0 {
+			r[i] = r[i-1]
+		}
+		if l[i] == 0 {
+			l[i] = l[i-1]
+		}
+	}
+	for i := 0; i < size-1; i += 2 {
+		audio[i], audio[i+1] = r[i/2], l[i/2]
+	}
+	return audio
+}
+
+func (Giongto35LinearResampler) Init(_, _ int) (err error) { return }
+
+func (Giongto35LinearResampler) Close() (err error) { return }
+
+func (r *SoxResampler) Init(in, out int) error {
+	r.buffer = bytes.NewBuffer([]byte{})
+	res, err := resample.New(
+		r.buffer,
+		float64(in),
+		float64(out),
+		2,
+		resample.I16,
+		resample.VeryHighQ,
+	)
+	if err != nil {
+		return err
+	}
+	r.backend = *res
+	return nil
+}
+
+func (r *SoxResampler) Resample(pcm []int16, size int) []int16 {
+	//defer r.buffer.Reset()
+	n, _ := r.backend.Write(toBytes(pcm))
+	log.Printf("pcm: %v, out: %v, n: %v, size: %v", len(pcm), r.buffer.Len(), n, size)
+	dat := r.buffer.Bytes()
+	return toInt16(dat)
+}
+
+func (r *SoxResampler) Close() error {
+	return r.backend.Close()
+}
+
+func toBytes(pcm []int16) (bytes []byte) {
+	bytes = make([]uint8, len(pcm)*2)
+	for i, k := 0, 0; i < len(pcm); i++ {
+		binary.LittleEndian.PutUint16(bytes[k:k+2], uint16(pcm[i]))
+		k += 2
+	}
+	return
+}
+
+func toInt16(bytes []byte) (pcm []int16) {
+	pcm = make([]int16, len(bytes)/2)
+	for i, k := 0, 0; i < len(pcm); i++ {
+		pcm[i] = int16(binary.LittleEndian.Uint16(bytes[k : k+2]))
+		k += 2
+	}
+	return
+}

--- a/pkg/encoder/opus/resampler_test.go
+++ b/pkg/encoder/opus/resampler_test.go
@@ -1,0 +1,28 @@
+package opus
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+func TestConverters(t *testing.T) {
+
+	var data []int16
+	for i := -32768; i < 32768; i ++ {
+		data = append(data, int16(i))
+	}
+
+	a := toBytes(data)
+	b := toInt16(a)
+
+	if !reflect.DeepEqual(data, b) {
+		t.Fatalf("convertion has failed, %v -> %v != %v", data, a, b)
+	}
+
+}


### PR DESCRIPTION
[SoX](http://sox.sourceforge.net/Docs/FAQ) is a canonical high-quality audio resampler used by everyone.

**Current issues**
Go wrappers for libsoxr are trash.
Some sample rates (esp. 32kHz) have a truncated number of samples for a given frame duration + output sample rate.
Clipping and distortion on low sample rates (32kHz), needs the use of intermediate phase instead of linear phasing/volume normalization, maybe? Requires RTFM.