### PR TITLE
Client game screen configuration support

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -162,7 +162,10 @@ body {
 
 
 #bottom-screen {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     width: 256px;
     height: 240px;
     position: absolute;
@@ -400,14 +403,18 @@ body {
     z-index: -1;
 }
 
-#game-screen {
-    overflow: hidden;
+.game-screen {
+    /*overflow: hidden;*/
     width: 100%;
-    height: 100%;
+    /*height: 100%;*/
     background-color: #222222;
     position: absolute;
+    display: flex;
 }
 
+[hidden] {
+    display: none !important;
+}
 
 #menu-screen {
     position: relative; /*must not static*/

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -404,7 +404,6 @@ body {
     overflow: hidden;
     width: 100%;
     height: 100%;
-    display: none;
     background-color: #222222;
     position: absolute;
 }

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -67,6 +67,7 @@
 #settings-data {
     overflow-y: auto;
     height: 50vh;
+    padding: 1em 0;
 }
 
 .container {

--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,7 @@
             There is still audio because current audio flow is not from media but it is manually encoded (technical webRTC challenge). Later, when we can integrate audio to media, we can face the issue with mute again .
             https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
         -->
-        <video id="game-screen" muted playinfullscreen="false" playsinline></video>
+        <video id="game-screen" hidden muted playsinline preload="none"></video>
 
         <div id="menu-screen">
             <div id="menu-container">
@@ -122,6 +122,7 @@
 <script src="/static/js/env.js?v=5"></script>
 <script src="/static/js/input/input.js?v=3"></script>
 <script src="/static/js/gameList.js?v=3"></script>
+<script src="/static/js/stream/stream.js?v=1"></script>
 <script src="/static/js/room.js?v=3"></script>
 <script src="/static/js/stats/stats.js?v=1"></script>
 <script src="/static/js/network/ajax.js?v=3"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -32,12 +32,12 @@
     </div>
 
     <div id="bottom-screen">
-        <div id="stats-overlay" class="no-select" hidden></div>
+        <div id="stats-overlay" class="no-select"></div>
         <!--NOTE: New browser doesn't allow unmuted video player. So we muted here.
             There is still audio because current audio flow is not from media but it is manually encoded (technical webRTC challenge). Later, when we can integrate audio to media, we can face the issue with mute again .
             https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
         -->
-        <video id="game-screen" hidden muted playsinline preload="none"></video>
+        <video id="stream" class="game-screen" hidden muted playsinline preload="none"></video>
 
         <div id="menu-screen">
             <div id="menu-container">

--- a/web/js/gameList.js
+++ b/web/js/gameList.js
@@ -63,8 +63,6 @@ const gameList = (() => {
 
     const startGamePickerTimer = (upDirection) => {
         if (gamePickTimer !== null) return;
-
-        log.debug('[games] start game picker timer');
         const shift = upDirection ? -1 : 1;
         pickGame(gameIndex + shift);
 
@@ -77,8 +75,6 @@ const gameList = (() => {
 
     const stopGamePickerTimer = () => {
         if (gamePickTimer === null) return;
-
-        log.debug('[games] stop game picker timer');
         clearInterval(gamePickTimer);
         gamePickTimer = null;
     };

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -57,6 +57,7 @@ const gui = (() => {
     }
 
     return {
+        create: _create,
         select,
         binding,
     }

--- a/web/js/init.js
+++ b/web/js/init.js
@@ -4,6 +4,7 @@ log.setLevel(settings.loadOr(opts.LOG_LEVEL, 'debug'));
 keyboard.init();
 joystick.init();
 touch.init();
+stream.init();
 
 [roomId, zone] = room.loadMaybe();
 // if from URL -> start game immediately!

--- a/web/js/settings/opts.js
+++ b/web/js/settings/opts.js
@@ -9,5 +9,6 @@
 const opts = Object.freeze({
     _VERSION: '_version',
     LOG_LEVEL: 'log.level',
-    INPUT_KEYBOARD_MAP: 'input.keyboard.map'
+    INPUT_KEYBOARD_MAP: 'input.keyboard.map',
+    MIRROR_SCREEN: 'mirror.screen'
 });

--- a/web/js/settings/settings.js
+++ b/web/js/settings/settings.js
@@ -456,6 +456,11 @@ settings._renderrer = (() => {
                         .add(Object.keys(value).map(k => gui.binding(value[k], k, onKeyBindingChange)))
                         .build();
                     break;
+                case opts.MIRROR_SCREEN:
+                    _option(data).withName('Video mirroring without smooth')
+                        .add(gui.select(k, onChange, ['mirror'], value))
+                        .build();
+                    break;
                 default:
                     _option(data).withName(k).add(value).build();
             }

--- a/web/js/stream/stream.js
+++ b/web/js/stream/stream.js
@@ -1,0 +1,58 @@
+/**
+ * Game streaming module.
+ * Contains HTML5 AV media elements.
+ *
+ * @version 1
+ */
+const stream = (() => {
+    const opts = {
+        volume: 0.5,
+        poster: '/static/img/screen_loading.gif'
+    };
+
+    const screen = document.getElementById('game-screen');
+
+    const mute = (mute) => screen.muted = mute
+
+    const stream = () => {
+        screen.play()
+            .then(() => log.info('Media can autoplay'))
+            .catch(error => {
+                // Usually error happens when we autoplay unmuted video, browser requires manual play.
+                // We already muted video and use separate audio encoding so it's fine now
+                log.error('Media Failed to autoplay');
+                log.error(error)
+                // TODO: Consider workaround
+            });
+    }
+
+    const toggle = (show) => screen.toggleAttribute('hidden', !show)
+
+    const toggleFullscreen = () => {
+        let h = parseFloat(getComputedStyle(screen, null).height.replace('px', ''))
+        env.display().toggleFullscreen(h !== window.innerHeight, screen);
+    }
+
+    const getVideoEl = () => screen
+
+
+    screen.addEventListener('loadstart', () => {
+        screen.volume = opts.volume;
+        screen.poster = opts.poster;
+    });
+    screen.addEventListener('canplay', () => {
+        screen.poster = '';
+    });
+
+    return Object.freeze({
+        audio: {
+            mute
+        },
+        video: {
+            toggleFullscreen,
+            el: getVideoEl
+        },
+        play: stream,
+        toggle,
+    })
+})(env, log);

--- a/web/js/stream/stream.js
+++ b/web/js/stream/stream.js
@@ -5,54 +5,99 @@
  * @version 1
  */
 const stream = (() => {
-    const opts = {
-        volume: 0.5,
-        poster: '/static/img/screen_loading.gif'
-    };
+        const screen = document.getElementById('stream');
 
-    const screen = document.getElementById('game-screen');
+        let opts = {
+                volume: 0.5,
+                poster: '/static/img/screen_loading.gif',
+                mirrorUpdateRate: 1 / 60,
+            },
+            state = {
+                screen: screen,
+                timerId: null,
+            };
 
-    const mute = (mute) => screen.muted = mute
+        const mute = (mute) => screen.muted = mute
 
-    const stream = () => {
-        screen.play()
-            .then(() => log.info('Media can autoplay'))
-            .catch(error => {
-                // Usually error happens when we autoplay unmuted video, browser requires manual play.
-                // We already muted video and use separate audio encoding so it's fine now
-                log.error('Media Failed to autoplay');
-                log.error(error)
-                // TODO: Consider workaround
-            });
+        const stream = () => {
+            screen.play()
+                .then(() => log.info('Media can autoplay'))
+                .catch(error => {
+                    // Usually error happens when we autoplay unmuted video, browser requires manual play.
+                    // We already muted video and use separate audio encoding so it's fine now
+                    log.error('Media Failed to autoplay');
+                    log.error(error)
+                    // TODO: Consider workaround
+                });
+        }
+
+        const toggle = (show) => {
+            state.screen.toggleAttribute('hidden', !show)
+        }
+
+        const toggleFullscreen = () => {
+            let h = parseFloat(getComputedStyle(state.screen, null)
+                .height
+                .replace('px', '')
+            )
+            env.display().toggleFullscreen(h !== window.innerHeight, state.screen);
+        }
+
+        const getVideoEl = () => screen
+
+        screen.addEventListener('loadedmetadata', () => {
+            if (state.screen !== screen) {
+                state.screen.setAttribute('width', screen.videoWidth);
+                state.screen.setAttribute('height', screen.videoHeight);
+            }
+        }, false);
+        screen.addEventListener('loadstart', () => {
+            screen.volume = opts.volume;
+            screen.poster = opts.poster;
+        }, false);
+        screen.addEventListener('canplay', () => {
+            screen.poster = '';
+        }, false);
+
+        const useCustomScreen = (use) => {
+            if (use) {
+                let id = state.screen.getAttribute('id');
+                if (id === 'canvas-mirror') return;
+
+                const canvas = gui.create('canvas');
+                canvas.setAttribute('id', 'canvas-mirror');
+                canvas.setAttribute('hidden', '');
+                canvas.setAttribute('width', screen.videoWidth);
+                canvas.setAttribute('height', screen.videoHeight);
+                canvas.style['image-rendering'] = 'pixelated';
+                canvas.classList.add('game-screen');
+
+                screen.parentNode.insertBefore(canvas, screen.nextSibling);
+                toggle(false)
+                state.screen = canvas
+                toggle(true)
+                let surface = canvas.getContext('2d');
+                state.timerId = setInterval(function () {
+                    if (screen.paused || screen.ended || !surface) return;
+                    surface.drawImage(screen, 0, 0);
+                }, opts.mirrorUpdateRate);
+            } else {
+                clearInterval(state.timerId);
+                let mirror = state.screen;
+                state.screen = screen;
+                toggle(true);
+                if (mirror !== screen) {
+                    mirror.parentNode.removeChild(mirror);
+                }
+            }
+        }
+
+        return {
+            audio: {mute},
+            video: {toggleFullscreen, el: getVideoEl},
+            play: stream,
+            toggle,
+            useCustomScreen,
+        }
     }
-
-    const toggle = (show) => screen.toggleAttribute('hidden', !show)
-
-    const toggleFullscreen = () => {
-        let h = parseFloat(getComputedStyle(screen, null).height.replace('px', ''))
-        env.display().toggleFullscreen(h !== window.innerHeight, screen);
-    }
-
-    const getVideoEl = () => screen
-
-
-    screen.addEventListener('loadstart', () => {
-        screen.volume = opts.volume;
-        screen.poster = opts.poster;
-    });
-    screen.addEventListener('canplay', () => {
-        screen.poster = '';
-    });
-
-    return Object.freeze({
-        audio: {
-            mute
-        },
-        video: {
-            toggleFullscreen,
-            el: getVideoEl
-        },
-        play: stream,
-        toggle,
-    })
-})(env, log);
+)(env, gui, log);


### PR DESCRIPTION
Added video output into a canvas surface. That allows disabling default bilinear video frame image scaling as well as customizing various post-processing parameters in the future that not allowed for the `<video>` elements (browsers don't support it).
There is a parameter in the settings which controls the output to the canvas. Be aware that canvas output requires noticeable CPU work since it will copy and draw every video frame, 60 times a second.