### PR TITLE
Disable PIE (ASLR) build mode for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           echo -e " 2\r\n 8\r\n " >> commands
           ./mesa/systemwidedeploy.cmd < ./commands
 
-          make build
+          make WORKER_BUILD_PARAMS=-buildmode=exe build
 
       - name: Build Linux app
         if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clean:
 
 build:
 	go build -a -tags netgo -ldflags '-w' -o bin/coordinator ./cmd/coordinator
-	go build -a -tags netgo -ldflags '-w' -o bin/worker ./cmd/worker
+	go build ${WORKER_BUILD_PARAMS} -a -tags netgo -ldflags '-w' -o bin/worker ./cmd/worker
 
 dev.tools:
 	./hack/scripts/install_tools.sh
@@ -70,7 +70,7 @@ dev.build: compile build
 
 dev.build-local:
 	go build -o bin/coordinator ./cmd/coordinator
-	go build -o bin/worker ./cmd/worker
+	go build ${WORKER_BUILD_PARAMS} -o bin/worker ./cmd/worker
 
 dev.run: dev.build-local
 	./bin/coordinator --v=5 &


### PR DESCRIPTION
Since Go version 1.15 ASLR security mode is enabled by default for Windows builds. In order to make it work without random NPE crashes in the cores (as an example in PSX games during load), you have to (re)compile every core with ASLR support or just disable this mode.

See: https://github.com/golang/go/issues/35192