### PR TITLE
Refactor input for safe concurrency

### DIFF
--- a/pkg/emulator/libretro/nanoarch/input.go
+++ b/pkg/emulator/libretro/nanoarch/input.go
@@ -1,0 +1,25 @@
+package nanoarch
+
+const numAxes = 4
+const maxPort = 8
+
+const (
+	InputTerminate = 0xFFFF
+)
+
+type controllerState struct {
+	keyState uint16
+	axes     [numAxes]int16
+}
+
+type controllers struct {
+	state map[string][]controllerState
+}
+
+type InputEvent struct {
+	RawState  []byte
+	PlayerIdx int
+	ConnID    string
+}
+
+func (ie InputEvent) bitmap() uint16 { return uint16(ie.RawState[1])<<8 + uint16(ie.RawState[0]) }

--- a/pkg/emulator/libretro/nanoarch/input.go
+++ b/pkg/emulator/libretro/nanoarch/input.go
@@ -12,8 +12,58 @@ type controllerState struct {
 	axes     [numAxes]int16
 }
 
-type controllers struct {
+type players struct {
+	session playerSession
+}
+
+type playerSession struct {
 	state map[string][]controllerState
+}
+
+func NewPlayerSessionInput() players {
+	return players{
+		session: playerSession{
+			state: map[string][]controllerState{},
+		},
+	}
+}
+
+func (ps *playerSession) close(id string) {
+	delete(ps.state, id)
+}
+
+func (ps *playerSession) poke(id string) {
+	if _, ok := ps.state[id]; !ok {
+		ps.state[id] = make([]controllerState, maxPort)
+	}
+}
+
+func (ps *playerSession) setInputForPlayer(id string, player int, buttons uint16, dpad []byte) {
+	ps.poke(id)
+
+	ps.state[id][player].keyState = buttons
+	for i := 0; i < numAxes && (i+1)*2+1 < len(dpad); i++ {
+		ps.state[id][player].axes[i] = int16(dpad[(i+1)*2+1])<<8 + int16(dpad[(i+1)*2])
+	}
+}
+
+func (ps *playerSession) isKeyPressed(player uint, key int) (pressed bool) {
+	for k := range ps.state {
+		if ((ps.state[k][player].keyState >> uint(key)) & 1) == 1 {
+			return true
+		}
+	}
+	return
+}
+
+func (ps *playerSession) isDpad(player uint, axis uint) (shift int16) {
+	for k := range ps.state {
+		value := ps.state[k][player].axes[axis]
+		if value != 0 {
+			return value
+		}
+	}
+	return
 }
 
 type InputEvent struct {

--- a/pkg/emulator/libretro/nanoarch/input_test.go
+++ b/pkg/emulator/libretro/nanoarch/input_test.go
@@ -1,0 +1,27 @@
+package nanoarch
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestConcurrentInput(t *testing.T) {
+	players := NewPlayerSessionInput()
+
+	session := "mad-test-session"
+	events := 1000
+	go func() {
+		for i := 0; i < events*2; i++ {
+			player := rand.Intn(controllersNum)
+			go players.session.setInput(session, player, 100, []byte{})
+			// here it usually crashes
+			go players.session.close(session)
+		}
+	}()
+	go func() {
+		for i := 0; i < events*2; i++ {
+			player := rand.Intn(controllersNum)
+			go players.isKeyPressed(uint(player), 100)
+		}
+	}()
+}

--- a/pkg/emulator/libretro/nanoarch/nanoarch.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch.go
@@ -182,11 +182,9 @@ func coreInputState(port C.unsigned, device C.unsigned, index C.unsigned, id C.u
 			return 0
 		}
 		axis := index*2 + id
-		for k := range NAEmulator.controllersMap {
-			value := NAEmulator.controllersMap[k][port].axes[axis]
-			if value != 0 {
-				return (C.int16_t)(value)
-			}
+		value := NAEmulator.players.session.isDpad(uint(port), uint(axis))
+		if value != 0 {
+			return (C.int16_t)(value)
 		}
 	}
 
@@ -200,12 +198,10 @@ func coreInputState(port C.unsigned, device C.unsigned, index C.unsigned, id C.u
 		return 0
 	}
 
-	// check if any player is pressing that key
-	for k := range NAEmulator.controllersMap {
-		if ((NAEmulator.controllersMap[k][port].keyState >> uint(key)) & 1) == 1 {
-			return 1
-		}
+	if NAEmulator.players.session.isKeyPressed(uint(port), key) {
+		return 1
 	}
+
 	return 0
 }
 

--- a/pkg/emulator/libretro/nanoarch/nanoarch.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch.go
@@ -182,7 +182,7 @@ func coreInputState(port C.unsigned, device C.unsigned, index C.unsigned, id C.u
 			return 0
 		}
 		axis := index*2 + id
-		value := NAEmulator.players.session.isDpad(uint(port), uint(axis))
+		value := NAEmulator.players.isDpadTouched(uint(port), uint(axis))
 		if value != 0 {
 			return (C.int16_t)(value)
 		}
@@ -198,7 +198,7 @@ func coreInputState(port C.unsigned, device C.unsigned, index C.unsigned, id C.u
 		return 0
 	}
 
-	if NAEmulator.players.session.isKeyPressed(uint(port), key) {
+	if NAEmulator.players.isKeyPressed(uint(port), key) {
 		return 1
 	}
 

--- a/pkg/emulator/libretro/nanoarch/nanoarch_test.go
+++ b/pkg/emulator/libretro/nanoarch/nanoarch_test.go
@@ -91,9 +91,9 @@ func GetEmulatorMock(room string, system string) *EmulatorMock {
 				UsesLibCo:   meta.UsesLibCo,
 				HasMultitap: meta.HasMultitap,
 			},
-			controllersMap: map[string][]controllerState{},
-			roomID:         room,
-			done:           make(chan struct{}, 1),
+			players: NewPlayerSessionInput(),
+			roomID:  room,
+			done:    make(chan struct{}, 1),
 		},
 
 		canvas: image.NewRGBA(image.Rect(0, 0, meta.Width, meta.Height)),

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -368,7 +368,7 @@ body {
 
 #room-txt {
     position: absolute;
-    width: 98px;
+    width: 59px;
     top: 45px;
     left: 23px;
     color: #bababa;
@@ -679,7 +679,7 @@ body {
   width: 35px;
   height: 20px;
 
-  top: 15px;
+  top: 44px;
   left: 85px;
 }
 

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -4,9 +4,8 @@
 }
 
 #btn-settings {
-    position: relative;
     top: 14px;
-    left: 62px;
+    left: 70px;
 }
 
 .modal-window {

--- a/web/index.html
+++ b/web/index.html
@@ -72,6 +72,11 @@
     <!-- TODO: remove -->
     <input id="room-txt" type="text" placeholder="room id..." unselectable="on" class=" unselectable" disabled>
 
+    <label class="dpad-toggle-label" title="D-pad toggle">
+        <input type="checkbox" id="dpad-toggle" checked>
+        <span class="dpad-toggle-slider"></span>
+    </label>
+
     <div id="noti-box" unselectable="on" class="unselectable">Oh my god</div>
 
     <div id="help-overlay">
@@ -99,10 +104,6 @@
             * -- applied after application restart
         </div>
     </div>
-    <label class="dpad-toggle-label">
-        <input type="checkbox" id="dpad-toggle" checked>
-        <span class="dpad-toggle-slider"></span>
-    </label>
 </div>
 
 <a id="ribbon" style="position: fixed; right: 0; top: 0;" href="https://github.com/giongto35/cloud-game"><img


### PR DESCRIPTION
To fix concurrent map access.

Interesting controller handling. 
Completely forgot how it supposed to work. 🤦 

So it's a map: `connection.id` → `[player index / 8]{ bitmap, axes / 4}`.
Should be synchronized on connections and players.

Added RWmutex on the whole map.