### PR TITLE
Use identical core images for build/target stages in the main Docker …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,32 @@
 ARG BUILD_PATH=/go/src/github.com/giongto35/cloud-game
 
 # build image
-FROM golang:1.16 AS build
+FROM debian:bullseye-slim AS build
 ARG BUILD_PATH
 WORKDIR ${BUILD_PATH}
 
 # system libs layer
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    gcc \
     make \
     pkg-config \
+    wget \
+    ca-certificates \
     libvpx-dev \
     libx264-dev \
     libopus-dev \
     libopusfile-dev \
     libsdl2-dev \
  && rm -rf /var/lib/apt/lists/*
+
+# go setup layer
+ARG GO=go1.16.2.linux-amd64.tar.gz
+RUN wget -q https://golang.org/dl/$GO \
+    && rm -rf /usr/local/go \
+    && tar -C /usr/local -xzf $GO \
+    && rm $GO
+ENV PATH="${PATH}:/usr/local/go/bin"
+RUN go version
 
 # go deps layer
 COPY go.mod go.sum ./
@@ -26,14 +38,14 @@ COPY ./ ./
 RUN make build
 
 # base image
-FROM debian:10-slim
+FROM debian:bullseye-slim
 ARG BUILD_PATH
 WORKDIR /usr/local/share/cloud-game
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates \
-    libvpx5 \
-    libx264-155 \
+    libvpx6 \
+    libx264-160 \
     libopus0 \
     libopusfile0 \
     libsdl2-2.0-0 \


### PR DESCRIPTION
…file.

It is possible that the official Golang Docker image used in the build stage may produce an executable file dynamically linked with some old libs that may not be present in the target OS image therefore use of identical Docker images are the better option.