### PR TITLE
Fix player select with touch controls

### DIFF
--- a/web/js/controller.js
+++ b/web/js/controller.js
@@ -406,6 +406,9 @@
     event.sub(GAME_ROOM_AVAILABLE, onGameRoomAvailable, 2);
     event.sub(GAME_SAVED, () => message.show('Saved'));
     event.sub(GAME_LOADED, () => message.show('Loaded'));
+    event.sub(GAME_PLAYER_IDX_CHANGE, data => {
+       updatePlayerIndex(data.index);
+    });
     event.sub(GAME_PLAYER_IDX, idx => {
         if (!isNaN(+idx)) message.show(+idx + 1);
     });

--- a/web/js/event/event.js
+++ b/web/js/event/event.js
@@ -62,6 +62,8 @@ const PING_RESPONSE = 'pingResponse';
 const GAME_ROOM_AVAILABLE = 'gameRoomAvailable';
 const GAME_SAVED = 'gameSaved';
 const GAME_LOADED = 'gameLoaded';
+// used to transfer the index value between touch and controller
+const GAME_PLAYER_IDX_CHANGE = 'gamePlayerIndexChange';
 const GAME_PLAYER_IDX = 'gamePlayerIndex';
 
 const CONNECTION_READY = 'connectionReady';

--- a/web/js/input/touch.js
+++ b/web/js/input/touch.js
@@ -165,8 +165,9 @@ const touch = (() => {
         }, 30);
     }
 
+    // !to rewrite slider completely
     function handlePlayerSlider() {
-        socket.updatePlayerIndex(this.value - 1);
+        event.pub(GAME_PLAYER_IDX_CHANGE, {index: +this.value - 1})
     }
 
     // Touch menu
@@ -279,6 +280,7 @@ const touch = (() => {
     playerSlider.addEventListener('oninput', handlePlayerSlider);
     playerSlider.addEventListener('onchange', handlePlayerSlider);
     playerSlider.addEventListener('mouseup', handlePlayerSlider);
+    playerSlider.addEventListener('touchend', handlePlayerSlider);
 
     // Bind events for menu
     // TODO change this flow


### PR DESCRIPTION
"Player slider" wasn't working on mobile devices in Chrome because there's no touch handler for the UI element.