### PR TITLE
Remove port binding for docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
     network_mode: "host"
     command: >
       bash -c "Xvfb :99 & coordinator --v=5 & worker --coordinatorhost localhost:8000"
-    ports:
-      - "8000:8000"
-      - "9000:9000"
     volumes:
       # keep cores persistent in the cloud-game_cores volume
       - cores:/usr/local/share/cloud-game/assets/cores


### PR DESCRIPTION
Docker-compose does not support host mode along with the port binding anymore. Additionally there is no necessity for using port binding under current configuration since it takes no effect.