### PR TITLE
Track worker's user count.

### DIFF
--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -217,6 +217,7 @@ func (o *Server) WS(w http.ResponseWriter, r *http.Request) {
 
 	// Assign available worker to browserClient
 	bc.WorkerID = wc.WorkerID
+	wc.UserCount++
 	wc.IsAvailable = false
 
 	// Everything is cool
@@ -239,7 +240,10 @@ func (o *Server) WS(w http.ResponseWriter, r *http.Request) {
 	wc.Send(api.TerminateSessionPacket(sessionID), nil)
 
 	// WorkerClient become available again
-	wc.IsAvailable = true
+	wc.UserCount--
+	if wc.UserCount <= 0 {
+		wc.IsAvailable = true
+	}
 }
 
 func (o *Server) getBestWorkerClient(client *BrowserClient, zone string) (*WorkerClient, error) {

--- a/pkg/coordinator/worker.go
+++ b/pkg/coordinator/worker.go
@@ -17,6 +17,7 @@ type WorkerClient struct {
 	PingServer     string
 	StunTurnServer string
 	IsAvailable    bool
+	UserCount      int
 	Zone           string
 }
 


### PR DESCRIPTION
If a worker is shared, then without tracking players it's impossible to tell when it's free, so we add a simple (not thread safe, meh) user counter.