### PR TITLE
Add version info into the apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,4 +113,4 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
-      - run: docker build .
+      - run: docker build --build-arg VERSION=$(./scripts/version.sh) .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,4 +113,4 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
-      - run: docker build --build-arg VERSION=$(bash ./scripts/version.sh) .
+      - run: docker build --build-arg VERSION=$(./scripts/version.sh) .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,4 +113,4 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
-      - run: docker build --build-arg VERSION=$(./scripts/version.sh) .
+      - run: docker build --build-arg VERSION=$(bash ./scripts/version.sh) .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -qq update && apt-get -qq install --no-install-recommends -y \
  && rm -rf /var/lib/apt/lists/*
 
 # go setup layer
-ARG GO=go1.16.3.linux-amd64.tar.gz
+ARG GO=go1.16.6.linux-amd64.tar.gz
 RUN wget -q https://golang.org/dl/$GO \
     && rm -rf /usr/local/go \
     && tar -C /usr/local -xzf $GO \
@@ -35,7 +35,9 @@ RUN go mod download
 COPY pkg ./pkg
 COPY cmd ./cmd
 COPY Makefile .
-RUN make build
+COPY scripts ./scripts
+ARG VERSION
+RUN GIT_VERSION=${VERSION} make build
 
 # base image
 FROM debian:bullseye-slim
@@ -51,5 +53,9 @@ RUN cp -s $(pwd)/* /usr/local/bin
 COPY assets/cores ./assets/cores
 COPY configs ./configs
 COPY web ./web
+ARG VERSION=Unspecified
+COPY scripts/version.sh version.sh
+RUN bash ./version.sh ./web/index.html ${VERSION} && \
+    rm -rf version.sh
 
 EXPOSE 8000 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN cp -s $(pwd)/* /usr/local/bin
 COPY assets/cores ./assets/cores
 COPY configs ./configs
 COPY web ./web
-ARG VERSION=Unspecified
+ARG VERSION
 COPY scripts/version.sh version.sh
 RUN bash ./version.sh ./web/index.html ${VERSION} && \
     rm -rf version.sh

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ clean:
 	@go clean ./cmd/*
 
 build:
-	CGO_ENABLED=0 go build -ldflags '-w -s' -o bin/ ./cmd/coordinator
-	go build -buildmode=exe -tags static -ldflags '-w -s' $(EXT_WFLAGS) -o bin/ ./cmd/worker
+	CGO_ENABLED=0 go build -ldflags "-w -s -X 'main.Version=$(GIT_VERSION)'" -o bin/ ./cmd/coordinator
+	go build -buildmode=exe -tags static -ldflags "-w -s -X 'main.Version=$(GIT_VERSION)'" $(EXT_WFLAGS) -o bin/ ./cmd/worker
 
 verify-cores:
 	go test -run TestAllEmulatorRooms ./pkg/worker/room -v -renderFrames $(GL_CTX) -outputPath "../../../_rendered"
@@ -120,6 +120,7 @@ CORES_DIR = assets/cores
 GAMES_DIR = assets/games
 .PHONY: release
 .SILENT: release
+release: GIT_VERSION := "$(shell bash ./scripts/version.sh)"
 release: clean build
 	rm -rf ./$(RELEASE_DIR) && mkdir ./$(RELEASE_DIR)
 	mkdir -p $(COORDINATOR_DIR) && mkdir -p $(WORKER_DIR)
@@ -133,6 +134,8 @@ release: clean build
 		$(DLIB_TOOL) $(WORKER_DIR) $(WORKER_DIR)/worker
     endif
 	cp -R ./web $(COORDINATOR_DIR)
+	# add version tag into index.html
+	shell bash ./scripts/version.sh $(COORDINATOR_DIR)/web/index.html
 	mkdir -p $(WORKER_DIR)/$(GAMES_DIR)
     ifneq (,$(wildcard ./$(GAMES_DIR)))
 		cp -R ./$(GAMES_DIR) $(WORKER_DIR)/assets

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ CORES_DIR = assets/cores
 GAMES_DIR = assets/games
 .PHONY: release
 .SILENT: release
-release: GIT_VERSION := "$(shell bash ./scripts/version.sh)"
+release: GIT_VERSION := "$(shell ./scripts/version.sh)"
 release: clean build
 	rm -rf ./$(RELEASE_DIR) && mkdir ./$(RELEASE_DIR)
 	mkdir -p $(COORDINATOR_DIR) && mkdir -p $(WORKER_DIR)
@@ -135,7 +135,7 @@ release: clean build
     endif
 	cp -R ./web $(COORDINATOR_DIR)
 	# add version tag into index.html
-	shell bash ./scripts/version.sh $(COORDINATOR_DIR)/web/index.html
+	shell ./scripts/version.sh $(COORDINATOR_DIR)/web/index.html
 	mkdir -p $(WORKER_DIR)/$(GAMES_DIR)
     ifneq (,$(wildcard ./$(GAMES_DIR)))
 		cp -R ./$(GAMES_DIR) $(WORKER_DIR)/assets

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -16,6 +16,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+var Version = "Unspecified"
+
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
@@ -28,6 +30,7 @@ func main() {
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
+	glog.Infof("[coordinator] version: %v", Version)
 	glog.Infof("Initializing coordinator server")
 	glog.V(4).Infof("Coordinator configs %v", conf)
 	o := coordinator.New(ctx, conf)

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -16,7 +16,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var Version = "Unspecified"
+var Version = ""
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,7 +17,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var Version = "Unspecified"
+var Version = ""
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,6 +17,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+var Version = "Unspecified"
+
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
@@ -31,6 +33,7 @@ func run() {
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
+	glog.Infof("[worker] version: %v", Version)
 	glog.V(4).Info("[worker] Initialization")
 	glog.V(4).Infof("[worker] Local configuration %+v", conf)
 	wrk := worker.New(ctx, conf)

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -16,8 +16,8 @@ from="(<span id=\"v\">).*?(<\/span>)"
 #
 # See: https://git-scm.com/docs/git-describe
 #
-# The first input param replaces the version placeholder when provided.
-# The second input param forces the use of some version instead of a git-derived one.
+# The first input param replaces the version placeholder in the provided file.
+# The second input param forces the use of some version value instead of a git-derived one.
 #
 if [ "$version" = "" ]; then
   version=$(git describe --abbrev=5 --always --tags 2> /dev/null)

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -19,7 +19,7 @@ from="(<span id=\"v\">).*?(<\/span>)"
 # The first input param replaces the version placeholder when provided.
 # The second input param forces the use of some version instead of a git-derived one.
 #
-if [ "$version" == "" ]; then
+if [ "$version" = "" ]; then
   version=$(git describe --abbrev=5 --always --tags 2> /dev/null)
 fi
 if [ "$file" != "" ]; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -11,7 +11,7 @@ from="(<span id=\"v\">).*?(<\/span>)"
 # |  | | |
 # |  | | '- commit hash of HEAD (1st 5 symbols)
 # |  | '-- "g" stands for git
-# |  '---- n commits since last tag
+# |  '---- n commits since the last tag
 # '------- last tag
 #
 # See: https://git-scm.com/docs/git-describe

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+file="$1"
+version="$2"
+from="(<span id=\"v\">).*?(<\/span>)"
+
+# Prints app version derived from git in the following format:
+#
+# v2-1-gcafeb
+# ^  ^ ^ ^
+# |  | | |
+# |  | | '- commit hash of HEAD (1st 5 symbols)
+# |  | '-- "g" stands for git
+# |  '---- n commits since last tag
+# '------- last tag
+#
+# See: https://git-scm.com/docs/git-describe
+#
+# Replaces version placeholder when the file param is provided.
+# Uses a provided version value instead of git.
+#
+if [ "$version" == "" ]; then
+  version=$(git describe --abbrev=5 --always --tags 2> /dev/null)
+fi
+if [ "$file" != "" ]; then
+  sed -i -E "s/$from/\1$version\2/" "$file"
+  echo "$file $version"
+else
+  echo "$version"
+fi

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -16,8 +16,8 @@ from="(<span id=\"v\">).*?(<\/span>)"
 #
 # See: https://git-scm.com/docs/git-describe
 #
-# Replaces version placeholder when the file param is provided.
-# Uses a provided version value instead of git.
+# The first input param replaces the version placeholder when provided.
+# The second input param forces the use of some version instead of a git-derived one.
 #
 if [ "$version" == "" ]; then
   version=$(git describe --abbrev=5 --always --tags 2> /dev/null)

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -780,3 +780,8 @@ input:checked + .dpad-toggle-slider:before {
     -ms-transform: translateX(15px);
     transform: translateX(15px);
 }
+
+#version {
+    color: #dddddd;
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -109,6 +109,10 @@
         src="https://github.blog/wp-content/uploads/2008/12/forkme_right_gray_6d6d6d.png?resize=149%2C149"
         class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1"></a>
 
+<div id="version">
+    <span id="v"></span>
+</div>
+
 <script src="/static/js/gui/gui.js?v=1"></script>
 <script src="/static/js/utils.js?v1"></script>
 <script src="/static/js/gui/message.js?v=1"></script>


### PR DESCRIPTION
Both worker and coordinator display version number in the console during startup. Coordinator displays its version number in the top right corner of the index.html page.
![image](https://user-images.githubusercontent.com/846874/125969354-6f033fbb-6fbc-4e14-bd17-340fa91600c7.png)

Version number's format (see: https://git-scm.com/docs/git-describe):
```
v2-1-gcafeb
^  ^ ^ ^
|  | | |
|  | | '- commit hash of HEAD (1st 5 symbols)
|  | '-- "g" stands for git
|  '---- n commits since the last tag
'------- last tag
```