### PR TITLE
Make Google Analytics injection optional

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -41,6 +41,9 @@ coordinator:
     httpsPort: 443
     httpsKey:
     httpsChain:
+  analytics:
+    inject: false
+    gtag:
 
 worker:
   network:

--- a/pkg/config/coordinator/config.go
+++ b/pkg/config/coordinator/config.go
@@ -12,6 +12,7 @@ import (
 
 type Config struct {
 	Coordinator struct {
+		Analytics    Analytics
 		PublicDomain string
 		PingServer   string
 		DebugHost    string
@@ -22,6 +23,12 @@ type Config struct {
 	Emulator    emulator.Emulator
 	Environment shared.Environment
 	Webrtc      webrtcConfig.Webrtc
+}
+
+// Analytics is optional Google Analytics
+type Analytics struct {
+	Inject bool
+	Gtag   string
 }
 
 // allows custom config path

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -73,7 +73,7 @@ func makeHTTPServer(server *Server) *http.Server {
 	r.HandleFunc("/ws", server.WS)
 	r.HandleFunc("/wso", server.WSO)
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./web"))))
-	r.PathPrefix("/").HandlerFunc(server.GetWeb)
+	r.PathPrefix("/").Handler(server.GetWeb(server.cfg))
 
 	svmux := &http.ServeMux{}
 	svmux.Handle("/", r)

--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -54,13 +54,18 @@ func NewServer(cfg coordinator.Config, library games.GameLibrary) *Server {
 }
 
 // GetWeb returns web frontend
-func (o *Server) GetWeb(w http.ResponseWriter, r *http.Request) {
-	tmpl, err := template.ParseFiles(index)
-	if err != nil {
-		log.Fatal(err)
-	}
+func (o *Server) GetWeb(conf coordinator.Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tpl, err := template.ParseFiles(index)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	tmpl.Execute(w, struct{}{})
+		// render index page with some tpl values
+		if err = tpl.Execute(w, conf.Coordinator.Analytics); err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 // getPingServer returns the server for latency check of a zone.

--- a/web/index.html
+++ b/web/index.html
@@ -137,19 +137,15 @@
 
 <script src="/static/js/init.js?v=5"></script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-145078282-1"></script>
+{{if .Inject}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{.Gtag}}"></script>
 <script>
     window.dataLayer = window.dataLayer || [];
-
-    function gtag() {
-        dataLayer.push(arguments);
-    }
-
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
-    gtag('config', 'UA-145078282-1');
+    gtag('config', '{{.Gtag}}');
 </script>
+{{end}}
 
 </body>
 


### PR DESCRIPTION
This allows switching GA client statistics on the client by setting these params in the config.yaml file:
 analytics:
   inject: false/true
   gtag: (your tag)
By default, GA analytics will be disabled.