### PR TITLE
Fix old Go non-existent build path error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ clean:
 	@go clean ./cmd/*
 
 build:
+	mkdir -p bin/
 	CGO_ENABLED=0 go build -ldflags "-w -s -X 'main.Version=$(GIT_VERSION)'" -o bin/ ./cmd/coordinator
 	go build -buildmode=exe -tags static -ldflags "-w -s -X 'main.Version=$(GIT_VERSION)'" $(EXT_WFLAGS) -o bin/ ./cmd/worker
 
@@ -69,6 +70,7 @@ verify-cores:
 dev.build: compile build
 
 dev.build-local:
+	mkdir -p bin/
 	CGO_ENABLED=0 go build -o bin/ ./cmd/coordinator
 	go build -buildmode=exe -o bin/ ./cmd/worker
 


### PR DESCRIPTION
If you specify just an output path without a filename when building the app, it will say that "build output dir/ already exists and is a directory" then it'll crash the build process.
This is considered a bug (https://github.com/golang/go/issues/41313) and was fixed in Go 1.16. The fix is for older versions.