### PR TITLE
Rework worker selection feature

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -3,6 +3,9 @@
 #
 
 coordinator:
+  # debugging switch
+  #   - allows selecting worker instances
+  debug: true
   # games library
   library:
     # some directory which is gonna be the root folder for the library
@@ -82,6 +85,8 @@ worker:
       # Own certs config
       httpsCert:
       httpsKey:
+  # optional server tag
+  tag:
 
 emulator:
   # set output viewport scale factor

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -5,7 +5,7 @@
 coordinator:
   # debugging switch
   #   - allows selecting worker instances
-  debug: true
+  debug: false
   # games library
   library:
     # some directory which is gonna be the root folder for the library

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rs/xid v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/veandco/go-sdl2 v0.4.10
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pkg/config/coordinator/config.go
+++ b/pkg/config/coordinator/config.go
@@ -12,6 +12,7 @@ import (
 
 type Config struct {
 	Coordinator struct {
+		Debug      bool
 		Library    games.Config
 		Monitoring monitoring.Config
 		Origin     struct {

--- a/pkg/config/worker/config.go
+++ b/pkg/config/worker/config.go
@@ -37,6 +37,7 @@ type Worker struct {
 		Zone               string
 	}
 	Server shared.Server
+	Tag    string
 }
 
 // allows custom config path

--- a/pkg/config/worker/config.go
+++ b/pkg/config/worker/config.go
@@ -89,7 +89,7 @@ func (c *Config) fixValues() {
 func (w *Worker) GetAddr() string { return w.Server.GetAddr() }
 
 // GetPingAddr returns exposed to clients server ping endpoint address.
-func (w *Worker) GetPingAddr(address string) string {
+func (w *Worker) GetPingAddr(address string) url.URL {
 	_, srcPort, _ := net.SplitHostPort(w.GetAddr())
 	dstHost, _, _ := net.SplitHostPort(address)
 	address = net.JoinHostPort(dstHost, srcPort)
@@ -109,5 +109,10 @@ func (w *Worker) GetPingAddr(address string) string {
 	if w.Server.Https {
 		pingURL.Scheme = "https"
 	}
-	return pingURL.String()
+	return pingURL
+}
+
+func (w *Worker) GetPort(address string) string {
+	_, port, _ := net.SplitHostPort(address)
+	return port
 }

--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -67,7 +67,9 @@ func (s *Server) WSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if connRt.PingAddr == "" {
+	log.Printf("%v", connRt)
+
+	if connRt.PingURL == "" {
 		log.Printf("Warning! Ping address is not set.")
 	}
 
@@ -94,8 +96,10 @@ func (s *Server) WSO(w http.ResponseWriter, r *http.Request) {
 	// Create a workerClient instance
 	wc := NewWorkerClient(c, workerID)
 	wc.Println("Generated worker ID")
+	wc.Addr = connRt.Addr
 	wc.Zone = connRt.Zone
-	wc.PingServer = connRt.PingAddr
+	wc.PingServer = connRt.PingURL
+	wc.Port = connRt.Port
 	wc.Tag = connRt.Tag
 
 	addr := getIP(c.RemoteAddr())
@@ -232,7 +236,6 @@ func (s *Server) getAvailableWorkers() map[string]*WorkerClient {
 			workerClients[k] = w
 		}
 	}
-
 	return workerClients
 }
 

--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"github.com/rs/xid"
@@ -187,18 +188,28 @@ func (s *Server) WS(w http.ResponseWriter, r *http.Request) {
 		// when we select one particular worker
 		if workerId != "" {
 			if xid_, err := xid.FromString(workerId); err == nil {
-				for _, w := range s.workerClients {
-					if xid_ == w.Id {
-						wc = w
-						bc.Printf("Found worker with id: %v", xid_)
-						break
+				if s.cfg.Coordinator.Debug {
+					for _, w := range s.workerClients {
+						if xid_ == w.Id {
+							wc = w
+							bc.Printf("[!] Worker found: %v", xid_)
+							break
+						}
+					}
+				} else {
+					for _, w := range s.workerClients {
+						if bytes.Equal(xid_.Machine(), w.Id.Machine()) {
+							wc = w
+							bc.Printf("[!] Machine %v found: %v", xid_.Machine(), xid_)
+							break
+						}
 					}
 				}
 			}
 		}
 
 		if wc == nil {
-			// Get best server for frontend to connect to
+			// Get the best server for frontend to connect to
 			wc, err = s.getBestWorkerClient(bc, userZone)
 			if err != nil {
 				return

--- a/pkg/coordinator/handlers.go
+++ b/pkg/coordinator/handlers.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"encoding/json"
 	"errors"
+	"github.com/rs/xid"
 	"log"
 	"math"
 	"net"
@@ -96,6 +97,7 @@ func (s *Server) WSO(w http.ResponseWriter, r *http.Request) {
 	// Create a workerClient instance
 	wc := NewWorkerClient(c, workerID)
 	wc.Println("Generated worker ID")
+	wc.Id = xid.New()
 	wc.Addr = connRt.Addr
 	wc.Zone = connRt.Zone
 	wc.PingServer = connRt.PingURL
@@ -103,7 +105,7 @@ func (s *Server) WSO(w http.ResponseWriter, r *http.Request) {
 	wc.Tag = connRt.Tag
 
 	addr := getIP(c.RemoteAddr())
-	wc.Printf("addr: %v | zone: %v | ping: %v | tag: %v", addr, wc.Zone, wc.PingServer, wc.Tag)
+	wc.Printf("id: %v | addr: %v | zone: %v | ping: %v | tag: %v", wc.Id, addr, wc.Zone, wc.PingServer, wc.Tag)
 	wc.StunTurnServer = ice.ToJson(s.cfg.Webrtc.IceServers, ice.Replacement{From: "server-ip", To: addr})
 
 	// Attach to Server instance with workerID, add defer

--- a/pkg/coordinator/routes.go
+++ b/pkg/coordinator/routes.go
@@ -30,4 +30,5 @@ func (s *Server) useragentRoutes(bc *BrowserClient) {
 	bc.Receive(api.GamePlayerSelect, bc.handleGamePlayerSelect(s))
 	bc.Receive(api.GameMultitap, bc.handleGameMultitap(s))
 	bc.Receive(api.GameRecording, bc.handleGameRecording(s))
+	bc.Receive(api.GetServerList, bc.handleGetServerList(s))
 }

--- a/pkg/coordinator/useragenthandlers.go
+++ b/pkg/coordinator/useragenthandlers.go
@@ -274,14 +274,14 @@ func (bc *BrowserClient) handleGetServerList(o *Server) cws.PacketHandler {
 			for _, s := range o.workerClients {
 				servers = append(servers, api.Server{
 					Addr: s.Addr, Id: s.WorkerID, IsBusy: !s.HasGameSlot(), PingURL: s.PingServer, Port: s.Port,
-					Tag: s.Tag, Zone: s.Zone,
+					Tag: s.Tag, Zone: s.Zone, Xid: s.Id.String(),
 				})
 			}
 		} else {
 			unique := map[string]*api.Server{}
 			for _, s := range o.workerClients {
 				if _, ok := unique[s.PingServer]; !ok {
-					unique[s.PingServer] = &api.Server{Addr: s.Addr, PingURL: s.PingServer}
+					unique[s.PingServer] = &api.Server{Addr: s.Addr, PingURL: s.PingServer, Xid: s.Id.String()}
 				}
 				unique[s.PingServer].Replicas++
 			}

--- a/pkg/coordinator/useragenthandlers.go
+++ b/pkg/coordinator/useragenthandlers.go
@@ -278,12 +278,14 @@ func (bc *BrowserClient) handleGetServerList(o *Server) cws.PacketHandler {
 				})
 			}
 		} else {
+			// not sure if []byte to string always reversible :/
 			unique := map[string]*api.Server{}
 			for _, s := range o.workerClients {
-				if _, ok := unique[s.PingServer]; !ok {
-					unique[s.PingServer] = &api.Server{Addr: s.Addr, PingURL: s.PingServer, Xid: s.Id.String()}
+				mid := string(s.Id.Machine())
+				if _, ok := unique[mid]; !ok {
+					unique[mid] = &api.Server{Addr: s.Addr, PingURL: s.PingServer, Xid: s.Id.String()}
 				}
-				unique[s.PingServer].Replicas++
+				unique[mid].Replicas++
 			}
 			for _, v := range unique {
 				servers = append(servers, *v)

--- a/pkg/coordinator/worker.go
+++ b/pkg/coordinator/worker.go
@@ -16,6 +16,7 @@ type WorkerClient struct {
 	// public server used for ping check
 	PingServer     string
 	StunTurnServer string
+	Tag            string
 	userCount      int // may be atomic
 	Zone           string
 

--- a/pkg/coordinator/worker.go
+++ b/pkg/coordinator/worker.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"fmt"
+	"github.com/rs/xid"
 	"log"
 	"sync"
 
@@ -11,6 +12,8 @@ import (
 
 type WorkerClient struct {
 	*cws.Client
+
+	Id xid.ID
 
 	WorkerID string
 	Addr     string

--- a/pkg/coordinator/worker.go
+++ b/pkg/coordinator/worker.go
@@ -13,8 +13,10 @@ type WorkerClient struct {
 	*cws.Client
 
 	WorkerID string
+	Addr     string
 	// public server used for ping check
 	PingServer     string
+	Port           string
 	StunTurnServer string
 	Tag            string
 	userCount      int // may be atomic

--- a/pkg/cws/api/coordinator.go
+++ b/pkg/cws/api/coordinator.go
@@ -52,10 +52,12 @@ func (packet *GameStartCall) From(data string) error { return from(packet, data)
 func (packet *GameStartCall) To() (string, error)    { return to(packet) }
 
 type ConnectionRequest struct {
-	IsHTTPS  bool   `json:"is_https,omitempty"`
-	PingAddr string `json:"ping_addr,omitempty"`
-	Tag      string `json:"tag,omitempty"`
-	Zone     string `json:"zone,omitempty"`
+	Addr    string `json:"addr,omitempty"`
+	IsHTTPS bool   `json:"is_https,omitempty"`
+	PingURL string `json:"ping_url,omitempty"`
+	Port    string `json:"port,omitempty"`
+	Tag     string `json:"tag,omitempty"`
+	Zone    string `json:"zone,omitempty"`
 }
 
 type GetServerListRequest struct{}
@@ -67,11 +69,14 @@ type GetServerListResponse struct {
 // Server is a separate machine that may contain
 // multiple sub-processes.
 type Server struct {
-	Addr   string `json:"addr"`
-	Id     string `json:"id,omitempty"`
-	IsBusy bool   `json:"is_busy,omitempty"`
-	Tag    string `json:"tag,omitempty"`
-	Zone   string `json:"zone,omitempty"`
+	Addr     string `json:"addr,omitempty"`
+	Id       string `json:"id,omitempty"`
+	IsBusy   bool   `json:"is_busy,omitempty"`
+	PingURL  string `json:"ping_url"`
+	Port     string `json:"port,omitempty"`
+	Replicas uint32 `json:"replicas,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+	Zone     string `json:"zone,omitempty"`
 }
 
 func (packet *GetServerListRequest) From(data string) error { return from(packet, data) }

--- a/pkg/cws/api/coordinator.go
+++ b/pkg/cws/api/coordinator.go
@@ -77,6 +77,7 @@ type Server struct {
 	Replicas uint32 `json:"replicas,omitempty"`
 	Tag      string `json:"tag,omitempty"`
 	Zone     string `json:"zone,omitempty"`
+	Xid      string `json:"xid,omitempty"`
 }
 
 func (packet *GetServerListRequest) From(data string) error { return from(packet, data) }

--- a/pkg/cws/api/coordinator.go
+++ b/pkg/cws/api/coordinator.go
@@ -21,6 +21,7 @@ const (
 	GamePlayerSelect = "player_index"
 	GameMultitap     = "multitap"
 	GameRecording    = "recording"
+	GetServerList    = "get_server_list"
 )
 
 type GameStartRequest struct {
@@ -51,10 +52,30 @@ func (packet *GameStartCall) From(data string) error { return from(packet, data)
 func (packet *GameStartCall) To() (string, error)    { return to(packet) }
 
 type ConnectionRequest struct {
-	Zone     string `json:"zone,omitempty"`
-	PingAddr string `json:"ping_addr,omitempty"`
 	IsHTTPS  bool   `json:"is_https,omitempty"`
+	PingAddr string `json:"ping_addr,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+	Zone     string `json:"zone,omitempty"`
 }
+
+type GetServerListRequest struct{}
+type GetServerListResponse struct {
+	Servers []Server `json:"servers"`
+}
+
+// Server contains a list of server groups.
+// Server is a separate machine that may contain
+// multiple sub-processes.
+type Server struct {
+	Addr   string `json:"addr"`
+	Id     string `json:"id,omitempty"`
+	IsBusy bool   `json:"is_busy,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+	Zone   string `json:"zone,omitempty"`
+}
+
+func (packet *GetServerListRequest) From(data string) error { return from(packet, data) }
+func (packet *GetServerListResponse) To() (string, error)   { return to(packet) }
 
 // packets
 

--- a/pkg/worker/handlers.go
+++ b/pkg/worker/handlers.go
@@ -127,12 +127,15 @@ func newCoordinatorConnection(host string, conf worker.Worker, addr string) (*Co
 	return NewCoordinatorClient(conn), nil
 }
 
-func MakeConnectionRequest(conf worker.Worker, address string) (string, error) {
+func MakeConnectionRequest(w worker.Worker, address string) (string, error) {
+	addr := w.GetPingAddr(address)
 	req := api.ConnectionRequest{
-		IsHTTPS:  conf.Server.Https,
-		PingAddr: conf.GetPingAddr(address),
-		Tag:      conf.Tag,
-		Zone:     conf.Network.Zone,
+		Addr:    addr.Hostname(),
+		IsHTTPS: w.Server.Https,
+		PingURL: addr.String(),
+		Port:    w.GetPort(address),
+		Tag:     w.Tag,
+		Zone:    w.Network.Zone,
 	}
 	rez, err := json.Marshal(req)
 	if err != nil {

--- a/pkg/worker/handlers.go
+++ b/pkg/worker/handlers.go
@@ -129,9 +129,10 @@ func newCoordinatorConnection(host string, conf worker.Worker, addr string) (*Co
 
 func MakeConnectionRequest(conf worker.Worker, address string) (string, error) {
 	req := api.ConnectionRequest{
-		Zone:     conf.Network.Zone,
-		PingAddr: conf.GetPingAddr(address),
 		IsHTTPS:  conf.Server.Https,
+		PingAddr: conf.GetPingAddr(address),
+		Tag:      conf.Tag,
+		Zone:     conf.Network.Zone,
 	}
 	rez, err := json.Marshal(req)
 	if err != nil {

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -7,6 +7,10 @@ html {
 body {
     background-image: url('/static/img/background.jpg');
     background-repeat: repeat;
+
+    align-items: center;
+    display: flex;
+    justify-content: center;
 }
 
 #gamebody {

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -14,8 +14,9 @@ body {
 }
 
 #gamebody {
+    display: flex;
+
     overflow: hidden;
-    display: block;
     width: 556px;
     height: 286px;
 
@@ -787,7 +788,7 @@ body {
 }
 
 .dpad-toggle-label {
-    position: relative;
+    position: absolute;
     display: inline-block;
     width: 35px;
     height: 20px;

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -843,3 +843,11 @@ input:checked + .dpad-toggle-slider:before {
     color: #dddddd;
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
+
+
+.source {
+    position: fixed;
+    bottom: 5px;
+    right: 5px;
+    color: white;
+}

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -231,10 +231,10 @@ body {
 
 #btn-help {
     padding-top: 0px;
-    width: 28px;
+    width: 20px;
     height: 28px;
 
-    top: 10px;
+    top: 16px;
     left: 23px;
 
     background-image: url('/static/img/ui/Help.png');
@@ -455,7 +455,7 @@ body {
 #room-txt {
     position: absolute;
     width: 59px;
-    top: 45px;
+    top: 48px;
     left: 23px;
     color: #bababa;
     padding-left: 0px;
@@ -794,7 +794,7 @@ body {
     width: 35px;
     height: 20px;
 
-    top: 44px;
+    top: 45px;
     left: 85px;
 }
 

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -281,7 +281,8 @@ body {
     background-image: url('/static/img/ui/bt REC.png');
 }
 
-.record {}
+.record {
+}
 
 .record-user {
     position: absolute;
@@ -839,15 +840,18 @@ input:checked + .dpad-toggle-slider:before {
     transform: translateX(15px);
 }
 
-#version {
-    color: #dddddd;
-    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
-}
-
-
 .source {
     position: fixed;
     bottom: 5px;
     right: 5px;
-    color: white;
+    color: #dddddd;
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+
+.source #v {
+    cursor: default;
+}
+
+.source a {
+    color: #dddddd;
 }

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -128,3 +128,32 @@
     flex-direction: column;
     align-items: center;
 }
+
+/* Server list styling */
+#server-list {
+    background-color: white;
+    font-size: 12px;
+
+    z-index: 1;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    padding: 1em;
+
+    opacity: .95;
+
+    cursor: default;
+}
+
+#server-list div {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    justify-items: start;
+
+    padding: 0 1em 0 1em;
+}
+
+#server-list .server-list__header {
+    font-weight: bold;
+    padding: 1em 1em 0 1em;
+}

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -177,14 +177,21 @@
     justify-content: space-between;
 
     align-items: center;
-    padding: .5rem;
+    padding: .5rem .8rem;
 
     background-color: #f5f5f5;
     border-bottom: 1px solid #dbdbdb;
+
+    user-select: none;
 }
 
 .panel__header__title {
     letter-spacing: 1px;
+}
+
+.panel__header__controls {
+    display: flex;
+    gap: 0.3rem;
 }
 
 .panel__content {
@@ -197,4 +204,21 @@
     justify-content: flex-end;
     /* Border */
     border-top: 1px solid rgba(0, 0, 0.3);
+}
+
+.panel__button {
+    background-color: #dbdbdb;
+
+    padding: 2px 4px;
+}
+
+.panel__button:hover {
+    background-color: #7a7e7d;
+    color: white;
+
+    cursor: pointer;
+}
+
+.panel__button.bold {
+    font-weight: bold;
 }

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -130,9 +130,11 @@
 }
 
 /* Server list styling */
-#server-list {
+#servers {
     background-color: white;
     font-size: 12px;
+
+    font-family: '6809', monospace;
 
     z-index: 1;
     position: absolute;
@@ -144,25 +146,55 @@
     cursor: default;
 }
 
-#server-list div {
+.server-list div {
     display: grid;
     grid-template-columns: .2fr 2.2fr 1fr .5fr .2fr;
     justify-items: start;
 
-    font-family: '6809', monospace;
 
     padding: 0 1em 0 1em;
 }
 
-#server-list div:not(.server-list__header):hover {
+.server-list div:not(.server-list__header):hover {
     background-color: #e7e7e7;
 }
 
-#server-list .server-list__header {
+.server-list .server-list__header {
     font-weight: bold;
     padding: 1em 1em .6em 1em;
 }
 
-#server-list .server-list__header span {
+.server-list .server-list__header span {
     border-bottom: 1px dashed black;
+}
+
+/* Panel element */
+.panel {
+}
+
+.panel__header {
+    display: flex;
+    justify-content: space-between;
+
+    align-items: center;
+    padding: .5rem;
+
+    background-color: #f5f5f5;
+    border-bottom: 1px solid #dbdbdb;
+}
+
+.panel__header__title {
+    letter-spacing: 1px;
+}
+
+.panel__content {
+    padding-top: .1rem;
+}
+
+.panel__footer {
+    display: flex;
+    /* Push the buttons to the right */
+    justify-content: flex-end;
+    /* Border */
+    border-top: 1px solid rgba(0, 0, 0.3);
 }

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -137,9 +137,7 @@
     font-family: '6809', monospace;
 
     z-index: 1;
-    position: absolute;
-    width: 100%;
-    height: 100%;
+    position: relative;
 
     opacity: .95;
 
@@ -170,6 +168,9 @@
 
 /* Panel element */
 .panel {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
 }
 
 .panel__header {
@@ -180,7 +181,6 @@
     padding: .5rem .8rem;
 
     background-color: #f5f5f5;
-    border-bottom: 1px solid #dbdbdb;
 
     user-select: none;
 }
@@ -207,9 +207,11 @@
 }
 
 .panel__button {
-    background-color: #dbdbdb;
+    background-color: #ededed;
 
     padding: 2px 4px;
+    width: 0.7rem;
+    text-align: center;
 }
 
 .panel__button:hover {

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -195,7 +195,8 @@
 }
 
 .panel__content {
-    padding-top: .1rem;
+    padding-bottom: .5rem;
+    overflow-y: auto;
 }
 
 .panel__footer {

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -146,7 +146,7 @@
 
 #server-list div {
     display: grid;
-    grid-template-columns: .2fr 2fr 1fr .5fr .2fr;
+    grid-template-columns: .2fr 2.2fr 1fr .5fr .2fr;
     justify-items: start;
 
     font-family: '6809', monospace;

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -147,7 +147,7 @@
 
 #server-list div {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: .3fr 2fr 1fr 1fr;
     justify-items: start;
 
     padding: 0 1em 0 1em;

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -224,3 +224,18 @@
 .panel__button.bold {
     font-weight: bold;
 }
+
+
+.app-button {
+    position: absolute;
+    top: 34px;
+    left: 45px;
+    cursor: pointer;
+    font-size: 70%;
+    color: #606060;
+    font-family: '6809', sans-serif;
+}
+
+.app-button:hover {
+    color: #7e7e7e;
+}

--- a/web/css/ui.css
+++ b/web/css/ui.css
@@ -138,7 +138,6 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    padding: 1em;
 
     opacity: .95;
 
@@ -147,13 +146,23 @@
 
 #server-list div {
     display: grid;
-    grid-template-columns: .3fr 2fr 1fr 1fr;
+    grid-template-columns: .2fr 2fr 1fr .5fr .2fr;
     justify-items: start;
+
+    font-family: '6809', monospace;
 
     padding: 0 1em 0 1em;
 }
 
+#server-list div:not(.server-list__header):hover {
+    background-color: #e7e7e7;
+}
+
 #server-list .server-list__header {
     font-weight: bold;
-    padding: 1em 1em 0 1em;
+    padding: 1em 1em .6em 1em;
+}
+
+#server-list .server-list__header span {
+    border-bottom: 1px dashed black;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@
         </div>
     </div>
 
-    <div id="servers" class="hidden"></div>
+    <div id="servers"></div>
 
     <div id="guide-txt"><b>Arrows</b>(move),<b>ZXCVAS</b>(game ABXYLR),<b>1/2</b>(1st/2nd player),<b>Shift/Enter/K/L</b>(select/start/save/load),<b>F</b>(fullscreen),<b>share</b>(copy
         sharelink to clipboard)

--- a/web/index.html
+++ b/web/index.html
@@ -112,12 +112,11 @@
     </div>
 </div>
 
-<a class="source" rel="noopener noreferrer" target="_blank" href="https://github.com/giongto35/cloud-game">
-    <span>Source code on GitHub</span>
-</a>
-
-<div id="version">
-    <span id="v"></span>
+<div class="source">
+    <span id="v">69ff8ae</span>
+    <a rel="noopener noreferrer" target="_blank" href="https://github.com/giongto35/cloud-game">
+        Source code on GitHub
+    </a>
 </div>
 
 <script src="/static/js/gui/gui.js?v=1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -112,7 +112,8 @@
     </div>
 </div>
 
-<a id="ribbon" style="position: fixed; right: 0; top: 0;" href="https://github.com/giongto35/cloud-game"><img
+<a id="ribbon" style="position: fixed; right: 0; top: 0;" rel="noopener noreferrer" target="_blank"
+   href="https://github.com/giongto35/cloud-game"><img
         width="149" height="149"
         src="https://github.blog/wp-content/uploads/2008/12/forkme_right_gray_6d6d6d.png?resize=149%2C149"
         class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1"></a>

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@
         </div>
     </div>
 
-    <div id="server-list" class="hidden"></div>
+    <div id="servers" class="hidden"></div>
 
     <div id="guide-txt"><b>Arrows</b>(move),<b>ZXCVAS</b>(game ABXYLR),<b>1/2</b>(1st/2nd player),<b>Shift/Enter/K/L</b>(select/start/save/load),<b>F</b>(fullscreen),<b>share</b>(copy
         sharelink to clipboard)

--- a/web/index.html
+++ b/web/index.html
@@ -123,7 +123,7 @@
 <script src="/static/js/utils.js?v1"></script>
 <script src="/static/js/gui/message.js?v=1"></script>
 <script src="/static/js/log.js?v=5"></script>
-<script src="/static/js/event/event.js?v=5"></script>
+<script src="/static/js/event/event.js?v=6"></script>
 <script src="/static/js/input/keys.js?v=3"></script>
 <script src="/static/js/settings/opts.js?v=1"></script>
 <script src="/static/js/settings/settings.js?v=2"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -112,11 +112,9 @@
     </div>
 </div>
 
-<a id="ribbon" style="position: fixed; right: 0; top: 0;" rel="noopener noreferrer" target="_blank"
-   href="https://github.com/giongto35/cloud-game"><img
-        width="149" height="149"
-        src="https://github.blog/wp-content/uploads/2008/12/forkme_right_gray_6d6d6d.png?resize=149%2C149"
-        class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1"></a>
+<a class="source" rel="noopener noreferrer" target="_blank" href="https://github.com/giongto35/cloud-game">
+    <span>Source code on GitHub</span>
+</a>
 
 <div id="version">
     <span id="v"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -47,6 +47,8 @@
         </div>
     </div>
 
+    <div id="server-list" class="hidden"></div>
+
     <div id="guide-txt"><b>Arrows</b>(move),<b>ZXCVAS</b>(game ABXYLR),<b>1/2</b>(1st/2nd player),<b>Shift/Enter/K/L</b>(select/start/save/load),<b>F</b>(fullscreen),<b>share</b>(copy
         sharelink to clipboard)
     </div>
@@ -124,16 +126,17 @@
 <script src="/static/js/gui/message.js?v=1"></script>
 <script src="/static/js/log.js?v=5"></script>
 <script src="/static/js/event/event.js?v=6"></script>
+<script src="/static/js/network/socket.js?v=4"></script>
 <script src="/static/js/input/keys.js?v=3"></script>
 <script src="/static/js/settings/opts.js?v=1"></script>
 <script src="/static/js/settings/settings.js?v=2"></script>
 <script src="/static/js/env.js?v=5"></script>
 <script src="/static/js/input/input.js?v=3"></script>
 <script src="/static/js/gameList.js?v=3"></script>
+<script src="/static/js/serverList.js?v=1"></script>
 <script src="/static/js/stream/stream.js?v=2"></script>
 <script src="/static/js/room.js?v=3"></script>
 <script src="/static/js/network/ajax.js?v=3"></script>
-<script src="/static/js/network/socket.js?v=4"></script>
 <script src="/static/js/network/rtcp.js?v=4"></script>
 <script src="/static/js/recording.js?v=1"></script>
 <script src="/static/js/stats/stats.js?v=2"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
 
 <body>
 <div id="gamebody">
-    <!--<div id="ui-emulator-bg"></div>-->
+    <div class="app-button" id="w" title="Workers">W</div>
 
     <div id="circle-pad-holder">
         <div id="btn-up" class="dpad" value="up"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -131,11 +131,11 @@
 <script src="/static/js/env.js?v=5"></script>
 <script src="/static/js/input/input.js?v=3"></script>
 <script src="/static/js/gameList.js?v=3"></script>
-<script src="/static/js/serverList.js?v=1"></script>
 <script src="/static/js/stream/stream.js?v=2"></script>
 <script src="/static/js/room.js?v=3"></script>
 <script src="/static/js/network/ajax.js?v=3"></script>
 <script src="/static/js/network/rtcp.js?v=4"></script>
+<script src="/static/js/workerManager.js?v=1"></script>
 <script src="/static/js/recording.js?v=1"></script>
 <script src="/static/js/stats/stats.js?v=2"></script>
 <script src="/static/js/controller.js?v=7"></script>

--- a/web/js/controller.js
+++ b/web/js/controller.js
@@ -72,22 +72,12 @@
         }
     };
 
-    const onLatencyCheck = (data) => {
+    const onLatencyCheck = async (data) => {
         message.show('Connecting to fastest server...');
-        const timeoutMs = 1111;
-        // deduplicate
-        const addresses = [...new Set(data.addresses || [])];
-
-        Promise.all(addresses.map(address => {
-            const start = Date.now();
-            return ajax.fetch(`${address}?_=${start}`, {method: "GET", redirect: "follow"}, timeoutMs)
-                .then(() => ({[address]: Date.now() - start}))
-                .catch(() => ({[address]: 9999}));
-        })).then(servers => {
-            const latencies = Object.assign({}, ...servers);
-            log.info('[ping] <->', latencies);
-            socket.latency(latencies, data.packetId);
-        });
+        const servers = await workerManager.checkLatencies(data);
+        const latencies = Object.assign({}, ...servers);
+        log.info('[ping] <->', latencies);
+        socket.latency(latencies, data.packetId);
     };
 
     const helpScreen = {

--- a/web/js/env.js
+++ b/web/js/env.js
@@ -2,7 +2,7 @@ const env = (() => {
     // UI
     const page = document.getElementsByTagName('html')[0];
     const gameBoy = document.getElementById('gamebody');
-    const ghRibbon = document.getElementById('ribbon');
+    const sourceLink = document.getElementsByClassName('source')[0];
 
     let isLayoutSwitched = false;
 
@@ -18,9 +18,16 @@ const env = (() => {
 
         rescaleGameBoy(targetWidth, targetHeight);
 
-        ghRibbon.style['bottom'] = isLayoutSwitched ? 0 : '';
-        ghRibbon.style['top'] = isLayoutSwitched ? '' : 0;
-        ghRibbon.style['transform'] = isLayoutSwitched ? 'rotate(90deg)' : '';
+        sourceLink.style['bottom'] = isLayoutSwitched ? 0 : '';
+        if (isLayoutSwitched) {
+            sourceLink.style.removeProperty('right');
+            sourceLink.style['left'] = 5;
+        } else {
+            sourceLink.style.removeProperty('left');
+            sourceLink.style['right'] = 5;
+        }
+        sourceLink.style['transform'] = isLayoutSwitched ? 'rotate(-90deg)' : '';
+        sourceLink.style['transform-origin'] = isLayoutSwitched ? 'left top' : '';
     };
 
     const rescaleGameBoy = (targetWidth, targetHeight) => {

--- a/web/js/event/event.js
+++ b/web/js/event/event.js
@@ -22,7 +22,7 @@ const event = (() => {
          * ...
          * sub01.unsub()
          */
-        sub: (topic, listener, order) => {
+        sub: (topic, listener, order = undefined) => {
             if (!topics[topic]) topics[topic] = {};
             // order index * big pad + next internal index (e.g. 1*100+1=101)
             // use some arbitrary big number to not overlap with non-ordered

--- a/web/js/event/event.js
+++ b/web/js/event/event.js
@@ -58,6 +58,8 @@ const LATENCY_CHECK_REQUESTED = 'latencyCheckRequested';
 const PING_REQUEST = 'pingRequest';
 const PING_RESPONSE = 'pingResponse';
 
+const GET_SERVER_LIST = 'getServerList';
+
 const GAME_ROOM_AVAILABLE = 'gameRoomAvailable';
 const GAME_SAVED = 'gameSaved';
 const GAME_LOADED = 'gameLoaded';
@@ -67,6 +69,7 @@ const GAME_PLAYER_IDX = 'gamePlayerIndex';
 
 const CONNECTION_READY = 'connectionReady';
 const CONNECTION_CLOSED = 'connectionClosed';
+const SOCKET_READY = 'socketReady'
 
 const MEDIA_STREAM_INITIALIZED = 'mediaStreamInitialized';
 const MEDIA_STREAM_SDP_AVAILABLE = 'mediaStreamSdpAvailable';

--- a/web/js/event/event.js
+++ b/web/js/event/event.js
@@ -69,7 +69,6 @@ const GAME_PLAYER_IDX = 'gamePlayerIndex';
 
 const CONNECTION_READY = 'connectionReady';
 const CONNECTION_CLOSED = 'connectionClosed';
-const SOCKET_READY = 'socketReady'
 
 const MEDIA_STREAM_INITIALIZED = 'mediaStreamInitialized';
 const MEDIA_STREAM_SDP_AVAILABLE = 'mediaStreamSdpAvailable';

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -36,6 +36,42 @@ const gui = (() => {
         return el;
     }
 
+    const panel = (root, title = '', cc = '', content) => {
+        const _root = root || _create('div');
+        _root.classList.add('panel');
+        const header = _create('div', (el) => el.classList.add('panel__header'));
+        const _content = _create('div', (el) => {
+            if (cc) {
+                el.classList.add(cc);
+            }
+            el.classList.add('panel__content')
+        });
+
+        header.append(_create('span', (el) => {
+            el.classList.add('panel__header__title');
+            el.innerText = title;
+        }));
+        header.append(_create('div', (el) => {
+            el.innerHTML = "<div style=\"color: rgba(0, 0, 0, 0.7);\"><div style=\"background-color: rgba(0, 0, 0, 0.3); border-radius: 9999px; height: 16px; width: 16px;\"></div></div>";
+            el.addEventListener('click', () => {
+                root.style.display = 'none';
+                //document.addEventListener('keydown', (e) => {
+                //   if (e.key === 'Escape') {
+
+                // }
+                //})
+            })
+        }))
+
+        root.append(header, _content);
+        if (content) {
+            _content.append(content);
+        }
+
+
+        return root;
+    }
+
     const _bind = (callback = function () {
     }, name = '', oldValue) => {
         const el = _create('button');
@@ -127,6 +163,7 @@ const gui = (() => {
         create: _create,
         fragment,
         hide,
+        panel,
         select,
         show,
         toggle,

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -5,7 +5,13 @@
  */
 const gui = (() => {
 
-    const _create = (name = 'div') => document.createElement(name);
+    const _create = (name = 'div', modFn) => {
+        const el = document.createElement(name);
+        if (modFn) {
+            modFn(el);
+        }
+        return el;
+    }
 
     const _option = (text = '', selected = false) => {
         const el = _create('option');
@@ -115,11 +121,11 @@ const gui = (() => {
             fadeOut,
             fadeInOut,
         },
-        create: _create,
-        select,
         binding,
-        show,
+        create: _create,
         hide,
+        select,
+        show,
         toggle,
     }
 })(document);

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -64,9 +64,8 @@ const gui = (() => {
 
             buttons.forEach((b => el.append(_create('span', (el) => {
                 el.classList.add('panel__button');
-                if (b.cl) {
-                    b.cl.forEach(class_ => el.classList.add(class_));
-                }
+                if (b.cl) b.cl.forEach(class_ => el.classList.add(class_));
+                if (b.title) el.title = b.title;
                 el.innerText = b.caption;
                 el.addEventListener('click', b.handler)
             }))))
@@ -74,6 +73,7 @@ const gui = (() => {
             el.append(_create('span', (el) => {
                 el.classList.add('panel__button');
                 el.innerText = 'X';
+                el.title = 'Close';
                 el.addEventListener('click', () => toggle(false))
             }))
         }))

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -107,6 +107,8 @@ const gui = (() => {
         )
     }
 
+    const fragment = () => document.createDocumentFragment();
+
     const sleep = async (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
     const fadeInOut = async (el, wait = 1000, speed = .1) => {
@@ -123,6 +125,7 @@ const gui = (() => {
         },
         binding,
         create: _create,
+        fragment,
         hide,
         select,
         show,

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -83,7 +83,7 @@ const gui = (() => {
         el.style.display = 'block';
         return new Promise((done) => (function fade() {
                 let val = parseFloat(el.style.opacity);
-                const proceed = ((val += 0.1) <= 1);
+                const proceed = ((val += speed) <= 1);
                 if (proceed) {
                     el.style.opacity = '' + val;
                     requestAnimationFrame(fade);

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -36,7 +36,7 @@ const gui = (() => {
         return el;
     }
 
-    const panel = (root, title = '', cc = '', content, buttons) => {
+    const panel = (root, title = '', cc = '', content, buttons = []) => {
         const state = {
             shown: false,
             loading: false,
@@ -62,9 +62,11 @@ const gui = (() => {
         header.append(_create('div', (el) => {
             el.classList.add('panel__header__controls');
 
-            buttons?.forEach((b => el.append(_create('span', (el) => {
+            buttons.forEach((b => el.append(_create('span', (el) => {
                 el.classList.add('panel__button');
-                b?.cl.forEach(class_ => el.classList.add(class_));
+                if (b.cl) {
+                    b.cl.forEach(class_ => el.classList.add(class_));
+                }
                 el.innerText = b.caption;
                 el.addEventListener('click', b.handler)
             }))))

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -134,11 +134,11 @@ const gui = (() => {
     }
 
     const show = (el) => {
-        el.style.display = 'block';
+        el.style.removeProperty('visibility');
     }
 
     const hide = (el) => {
-        el.style.display = 'none';
+        el.style.visibility = 'hidden';
     }
 
     const toggle = (el, what) => {

--- a/web/js/gui/gui.js
+++ b/web/js/gui/gui.js
@@ -36,7 +36,13 @@ const gui = (() => {
         return el;
     }
 
-    const panel = (root, title = '', cc = '', content) => {
+    const panel = (root, title = '', cc = '', content, buttons) => {
+        const state = {
+            shown: false,
+            loading: false,
+            title: title,
+        }
+
         const _root = root || _create('div');
         _root.classList.add('panel');
         const header = _create('div', (el) => el.classList.add('panel__header'));
@@ -47,20 +53,27 @@ const gui = (() => {
             el.classList.add('panel__content')
         });
 
-        header.append(_create('span', (el) => {
+        const _title = _create('span', (el) => {
             el.classList.add('panel__header__title');
             el.innerText = title;
-        }));
-        header.append(_create('div', (el) => {
-            el.innerHTML = "<div style=\"color: rgba(0, 0, 0, 0.7);\"><div style=\"background-color: rgba(0, 0, 0, 0.3); border-radius: 9999px; height: 16px; width: 16px;\"></div></div>";
-            el.addEventListener('click', () => {
-                root.style.display = 'none';
-                //document.addEventListener('keydown', (e) => {
-                //   if (e.key === 'Escape') {
+        });
+        header.append(_title);
 
-                // }
-                //})
-            })
+        header.append(_create('div', (el) => {
+            el.classList.add('panel__header__controls');
+
+            buttons?.forEach((b => el.append(_create('span', (el) => {
+                el.classList.add('panel__button');
+                b?.cl.forEach(class_ => el.classList.add(class_));
+                el.innerText = b.caption;
+                el.addEventListener('click', b.handler)
+            }))))
+
+            el.append(_create('span', (el) => {
+                el.classList.add('panel__button');
+                el.innerText = 'X';
+                el.addEventListener('click', () => toggle(false))
+            }))
         }))
 
         root.append(header, _content);
@@ -68,8 +81,28 @@ const gui = (() => {
             _content.append(content);
         }
 
+        const setContent = (content) => _content.replaceChildren(content)
 
-        return root;
+        const setLoad = (load = true) => {
+            state.loading = load;
+            _title.innerText = state.loading ? `${state.title}...` : state.title;
+        }
+
+        function toggle(show) {
+            state.shown = show;
+            if (state.shown) {
+                gui.show(_root);
+            } else {
+                gui.hide(_root);
+            }
+        }
+
+        return {
+            isHidden: () => !state.shown,
+            setContent,
+            setLoad,
+            toggle,
+        }
     }
 
     const _bind = (callback = function () {

--- a/web/js/init.js
+++ b/web/js/init.js
@@ -7,5 +7,7 @@ touch.init();
 stream.init();
 
 [roomId, zone] = room.loadMaybe();
+// find worker id if present
+const wid = new URLSearchParams(document.location.search).get('wid');
 // if from URL -> start game immediately!
-socket.init(roomId, zone);
+socket.init(roomId, wid, zone);

--- a/web/js/network/socket.js
+++ b/web/js/network/socket.js
@@ -41,7 +41,7 @@ const socket = (() => {
             log.info('[ws] <- open connection');
             log.info(`[ws] -> setting ping interval to ${pingIntervalMs}ms`);
             // !to add destructor if SPA
-            pingIntervalId = setInterval(ping, pingIntervalMs)
+            pingIntervalId = setInterval(ping, pingIntervalMs);
         };
         conn.onerror = () => log.error('[ws] some error!');
         conn.onclose = (event) => log.info(`[ws] closed (${event.code})`);
@@ -59,6 +59,7 @@ const socket = (() => {
                     // const [stunturn, ...games] = data;
                     let serverData = JSON.parse(data.data);
                     event.pub(MEDIA_STREAM_INITIALIZED, {stunturn: serverData.shift(), games: serverData});
+                    event.pub(SOCKET_READY);
                     break;
                 case 'offer':
                     // this is offer from worker
@@ -89,6 +90,9 @@ const socket = (() => {
                     break;
                 case 'recording':
                     event.pub(RECORDING_STATUS_CHANGED, data.data);
+                    break;
+                case 'get_server_list':
+                    event.pub(GET_SERVER_LIST, JSON.parse(data.data));
                     break;
             }
         };
@@ -139,6 +143,7 @@ const socket = (() => {
     const toggleRecording = (active = false, userName = '') => send({
         "id": "recording", "data": JSON.stringify({"active": active, "user": userName,})
     })
+    const getServerList = () => send({"id": "get_server_list", "data": "{}"})
 
     return {
         init: init,
@@ -152,5 +157,6 @@ const socket = (() => {
         quitGame: quitGame,
         toggleMultitap: toggleMultitap,
         toggleRecording: toggleRecording,
+        getServerList,
     }
 })(event, log);

--- a/web/js/network/socket.js
+++ b/web/js/network/socket.js
@@ -27,7 +27,6 @@ const socket = (() => {
     let pingIntervalId = 0;
 
     let conn;
-    let curPacketId = '';
 
     const init = (roomId, zone) => {
         const params = new URLSearchParams({room_id: roomId, zone: zone}).toString()
@@ -84,9 +83,7 @@ const socket = (() => {
                     event.pub(GAME_PLAYER_IDX, data.data);
                     break;
                 case 'checkLatency':
-                    curPacketId = data.packet_id;
-                    const addresses = data.data.split(',');
-                    event.pub(LATENCY_CHECK_REQUESTED, {packetId: curPacketId, addresses: addresses});
+                    event.pub(LATENCY_CHECK_REQUESTED, {packetId: data.packet_id, addresses: data.data});
                     break;
                 case 'recording':
                     event.pub(RECORDING_STATUS_CHANGED, data.data);

--- a/web/js/network/socket.js
+++ b/web/js/network/socket.js
@@ -58,7 +58,6 @@ const socket = (() => {
                     // const [stunturn, ...games] = data;
                     let serverData = JSON.parse(data.data);
                     event.pub(MEDIA_STREAM_INITIALIZED, {stunturn: serverData.shift(), games: serverData});
-                    event.pub(SOCKET_READY);
                     break;
                 case 'offer':
                     // this is offer from worker

--- a/web/js/network/socket.js
+++ b/web/js/network/socket.js
@@ -28,8 +28,10 @@ const socket = (() => {
 
     let conn;
 
-    const init = (roomId, zone) => {
-        const params = new URLSearchParams({room_id: roomId, zone: zone}).toString()
+    const init = (roomId, wid, zone) => {
+        let objParams = {room_id: roomId, zone: zone};
+        if (wid) objParams.wid = wid;
+        const params = new URLSearchParams(objParams).toString()
         const address = `${location.protocol !== 'https:' ? 'ws' : 'wss'}://${location.host}/ws?${params}`;
         console.info(`[ws] connecting to ${address}`);
         conn = new WebSocket(address);

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -5,11 +5,12 @@
 const serverList = (() => {
     const id = 'servers',
         _class = 'server-list',
-        panel = gui.panel(document.getElementById(id), 'SERVERS', 'server-list', null, [
+        panel = gui.panel(document.getElementById(id), 'WORKERS', 'server-list', null, [
             {
                 caption: '⟳',
                 cl: ['bold'],
                 handler: handleReload,
+                title: 'Reload server data',
             }
         ]),
         index = ((i = 1) => ({v: () => i++, r: () => i = 1}))(),
@@ -32,6 +33,7 @@ const serverList = (() => {
                 renderer: (data) => data?.is_busy === true ? 'R' : ''
             },
             'use': {
+                caption: 'Use',
                 renderer: renderServerChangeEl
             }
         },

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -1,0 +1,66 @@
+/**
+ * Server list module.
+ * @version 1
+ */
+const serverList = (() => {
+    const blockName = 'server-list',
+        container = document.getElementById(blockName),
+        fields = ['addr', 'id', 'is_busy'],
+        field_caps = ['Address', 'ID', 'Use'];
+
+
+    // container.classList.add("hidden");
+
+    const state = {
+        servers: [],
+        shown: true,
+    }
+
+    const onReady = () => {
+        socket.getServerList()
+    }
+
+    const handleGetServerList = (data) => {
+        if (data && data['servers']) {
+            state.servers = data['servers'];
+            _render();
+        }
+    }
+
+    function _render() {
+        container.innerHTML = '';
+        if (!state.shown) {
+            container.classList.add('hidden');
+            return;
+        }
+
+        container.classList.remove('hidden');
+
+        if (state.servers.length > 0) {
+            const h = gui.create();
+            h.classList.add(`${blockName}__header`);
+            container.append(h);
+            field_caps.forEach(field => {
+                const f = gui.create('span');
+                f.innerText = field;
+                h.append(f);
+            })
+        }
+        state.servers.forEach(server => {
+            const row = gui.create();
+            fields.forEach(field => {
+                if (server.hasOwnProperty(field)) {
+                    const f = gui.create('span');
+                    f.innerText = server[field];
+                    row.append(f);
+                }
+            })
+            container.append(row);
+        })
+    }
+
+    event.sub(SOCKET_READY, onReady);
+    event.sub(GET_SERVER_LIST, handleGetServerList);
+
+    return {}
+})(document, event, gui, log, socket);

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -5,6 +5,7 @@
 const serverList = (() => {
     const id = 'servers',
         _class = 'server-list',
+        trigger = document.getElementById('w'),
         panel = gui.panel(document.getElementById(id), 'WORKERS', 'server-list', null, [
             {
                 caption: '⟳',
@@ -51,7 +52,6 @@ const serverList = (() => {
     }
 
     function _render(servers = []) {
-        panel.toggle(true);
         if (panel.isHidden()) return;
 
         const content = gui.fragment();
@@ -93,6 +93,13 @@ const serverList = (() => {
             el.addEventListener('click', handleServerChange);
         })
     }
+
+    panel.toggle(false);
+
+    trigger.addEventListener('click', () => {
+        handleReload();
+        panel.toggle(true);
+    })
 
     event.sub(SOCKET_READY, onReady);
     event.sub(GET_SERVER_LIST, onNewData);

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -23,7 +23,7 @@ const serverList = (() => {
             },
             'id': {
                 caption: 'ID',
-                renderer: (data) => data?.id ? data.id : `??? [replicated] x ${data['replicas']}`
+                renderer: (data) => data?.id ? data.xid : `??? [replicated] x ${data['replicas']}`
             },
             'addr': {
                 caption: 'Address',
@@ -39,8 +39,6 @@ const serverList = (() => {
             }
         },
         fields = Object.keys(list);
-
-    // root.classList.add("hidden");
 
     // waiting for the socket to request data
     const onReady = () => handleReload()

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -6,26 +6,26 @@ const serverList = (() => {
     const id = 'server-list',
         root = document.getElementById(id),
         index = ((i = 1) => () => i++)(),
-        // cap -- is a caption of the field
-        // mut -- is an arbitrary mutation of the field
+        // caption -- the field caption
+        // renderer -- is an arbitrary mutation of the field
         list = {
             'n': {
-                // print line number as 01
-                mut: () => String(index()).padStart(2, '0')
+                renderer: () => String(index()).padStart(2, '0')
             },
             'id': {
-                cap: 'ID', mut: (data) => data?.id ? data.id : `??? [replicated] x ${data['replicas']}`
+                caption: 'ID',
+                renderer: (data) => data?.id ? data.id : `??? [replicated] x ${data['replicas']}`
             },
             'addr': {
-                cap: 'Address', mut: (data) => data?.port ? `${data.addr}:${data.port}` : data.addr
+                caption: 'Address',
+                renderer: (data) => data?.port ? `${data.addr}:${data.port}` : data.addr
             },
-            'is_busy': {cap: 'State', mut: (data) => data.is_busy === true ? 'X' : ''},
+            'is_busy': {
+                caption: 'State',
+                renderer: (data) => data.is_busy === true ? 'X' : ''
+            },
             'use': {
-                mut: (_, handler) => gui.create('a', (el) => {
-                    el.innerText = '>>';
-                    el.href = "#";
-                    el.addEventListener('click', handler);
-                })
+                renderer: renderServerChangeEl
             }
         },
         fields = Object.keys(list);
@@ -33,19 +33,15 @@ const serverList = (() => {
     // root.classList.add("hidden");
 
     const state = {
-        servers: [],
         shown: true,
     }
 
-    // waiting for the server connection when it's ready
+    // waiting for the socket to request data
     const onReady = () => socket.getServerList()
 
-    const handleGetServerList = (data) => {
-        state.servers = data?.servers ? data.servers : [];
-        _render();
-    }
+    const onNewData = (dat = {servers: []}) => _render(dat?.servers)
 
-    function _render() {
+    function _render(servers = []) {
         if (!state.shown) {
             gui.hide(root);
             return;
@@ -53,7 +49,7 @@ const serverList = (() => {
         root.innerHTML = '';
         gui.show(root);
 
-        if (state.servers.length === 0) {
+        if (servers.length === 0) {
             root.append(gui.create('span', (el) => el.innerText = 'No data :('));
             return;
         }
@@ -61,33 +57,33 @@ const serverList = (() => {
         const frag = gui.fragment();
         const header = gui.create('div', (el) => {
             el.classList.add(`${id}__header`);
-            fields.forEach(field => el.append(gui.create('span', (f) => f.innerHTML = list[field]?.cap || '')))
+            fields.forEach(field => el.append(gui.create('span', (f) => f.innerHTML = list[field]?.caption || '')))
         });
-        frag.appendChild(header)
+        frag.append(header)
 
         const renderRow = (server) => (row) => fields.forEach(field => {
             const val = server.hasOwnProperty(field) ? server[field] : '';
-            const mut = list[field]?.mut;
-            row.appendChild(gui.create('span', (f) => {
-                    if (!mut) {
-                        f.innerHTML = val;
-                        return;
-                    }
-                    const content = mut(server, () => console.log(server.addr, server.id));
-                    if (content.nodeType) {
-                        f.appendChild(content);
-                        return;
-                    }
-                    f.innerHTML = content
-                })
-            );
+            const renderer = list[field]?.renderer;
+            row.append(gui.create('span', (f) => f.append(renderer ? renderer(server) : val)));
         })
-        state.servers.forEach(server => frag.appendChild(gui.create('div', renderRow(server))))
-        root.appendChild(frag);
+        servers.forEach(server => frag.append(gui.create('div', renderRow(server))))
+        root.append(frag);
+    }
+
+    function renderServerChangeEl(server) {
+        const handleServerChange = (e) => {
+            e.preventDefault();
+            console.log(server.addr, server.id);
+        }
+        return gui.create('a', (el) => {
+            el.innerText = '>>';
+            el.href = "#";
+            el.addEventListener('click', handleServerChange);
+        })
     }
 
     event.sub(SOCKET_READY, onReady);
-    event.sub(GET_SERVER_LIST, handleGetServerList);
+    event.sub(GET_SERVER_LIST, onNewData);
 
     return {}
 })(document, event, gui, log, socket);

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -7,7 +7,7 @@ const serverList = (() => {
         root = document.getElementById(id),
         index = ((i = 1) => () => i++)(),
         // caption -- the field caption
-        // renderer -- is an arbitrary mutation of the field
+        // renderer -- an arbitrary DOM output for the field
         list = {
             'n': {
                 renderer: () => String(index()).padStart(2, '0')
@@ -22,7 +22,7 @@ const serverList = (() => {
             },
             'is_busy': {
                 caption: 'State',
-                renderer: (data) => data.is_busy === true ? 'X' : ''
+                renderer: (data) => data?.is_busy === true ? 'X' : ''
             },
             'use': {
                 renderer: renderServerChangeEl

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -5,10 +5,14 @@
 const serverList = (() => {
     const id = 'server-list',
         root = document.getElementById(id),
+        index = ((i = 1) => () => i++)(),
         // cap -- is a caption of the field
         // mut -- ia a transformation function for the field value
         list = {
-            'n': {},
+            'n': {
+                // print line number as 01
+                mut: (_) => String(index()).padStart(2, '0')
+            },
             'id': {cap: 'ID'},
             'addr': {
                 cap: 'Address',
@@ -20,7 +24,8 @@ const serverList = (() => {
                     }
                 }
             },
-            'is_busy': {cap: 'Reserved', mut: (v) => v === true ? '◍' : ''}
+            'is_busy': {cap: 'State', mut: (v) => v === true ? 'X' : ''},
+            'use': {mut: (_) => '>>'}
         },
         fields = Object.keys(list);
 
@@ -39,14 +44,12 @@ const serverList = (() => {
         _render();
     }
 
-    const _index = (i = 0) => () => i++
-
     function _render() {
-        root.innerHTML = '';
         if (!state.shown) {
             gui.hide(root);
             return;
         }
+        root.innerHTML = '';
         gui.show(root);
 
         if (state.servers.length === 0) {
@@ -54,22 +57,20 @@ const serverList = (() => {
             return;
         }
 
+        const frag = gui.fragment();
         const header = gui.create('div', (el) => {
             el.classList.add(`${id}__header`);
-            fields.forEach(field => el.append(gui.create('span', (f) => f.innerText = list[field]?.cap || '')))
+            fields.forEach(field => el.append(gui.create('span', (f) => f.innerHTML = list[field]?.cap || '')))
         });
-        root.append(header);
+        frag.appendChild(header)
 
-        const renderRow = (server, i) => (row) => fields.forEach(field => {
-            const val = server.hasOwnProperty(field) ? server[field] :
-                // do row index
-                field === 'n' ? i
-                    : '';
+        const renderRow = (server) => (row) => fields.forEach(field => {
+            const val = server.hasOwnProperty(field) ? server[field] : '';
             const mut = list[field]?.mut;
-            row.append(gui.create('span', (f) => f.innerText = mut ? mut(val) : val));
+            row.appendChild(gui.create('span', (f) => f.innerHTML = mut ? mut(val) : val));
         })
-        const index = _index(1);
-        state.servers.forEach(server => root.append(gui.create('div', renderRow(server, index()))))
+        state.servers.forEach(server => frag.appendChild(gui.create('div', renderRow(server))))
+        root.appendChild(frag);
     }
 
     event.sub(SOCKET_READY, onReady);

--- a/web/js/serverList.js
+++ b/web/js/serverList.js
@@ -3,8 +3,9 @@
  * @version 1
  */
 const serverList = (() => {
-    const id = 'server-list',
-        root = document.getElementById(id),
+    const id = 'servers',
+        _class = 'server-list',
+        el = document.getElementById(id),
         index = ((i = 1) => () => i++)(),
         // caption -- the field caption
         // renderer -- an arbitrary DOM output for the field
@@ -43,11 +44,13 @@ const serverList = (() => {
 
     function _render(servers = []) {
         if (!state.shown) {
-            gui.hide(root);
+            gui.hide(el);
             return;
         }
-        root.innerHTML = '';
-        gui.show(root);
+        el.innerHTML = '';
+        gui.show(el);
+
+        const root = gui.fragment();
 
         if (servers.length === 0) {
             root.append(gui.create('span', (el) => el.innerText = 'No data :('));
@@ -56,7 +59,7 @@ const serverList = (() => {
 
         const frag = gui.fragment();
         const header = gui.create('div', (el) => {
-            el.classList.add(`${id}__header`);
+            el.classList.add(`${_class}__header`);
             fields.forEach(field => el.append(gui.create('span', (f) => f.innerHTML = list[field]?.caption || '')))
         });
         frag.append(header)
@@ -68,6 +71,7 @@ const serverList = (() => {
         })
         servers.forEach(server => frag.append(gui.create('div', renderRow(server))))
         root.append(frag);
+        gui.panel(el, 'SERVERS', 'server-list', root);
     }
 
     function renderServerChangeEl(server) {

--- a/web/js/workerManager.js
+++ b/web/js/workerManager.js
@@ -10,7 +10,7 @@ const workerManager = (() => {
             {
                 caption: '⟳',
                 cl: ['bold'],
-                handler: handleReload,
+                handler: utils.debounce(handleReload, 1000),
                 title: 'Reload server data',
             }
         ]),
@@ -23,7 +23,7 @@ const workerManager = (() => {
             },
             'id': {
                 caption: 'ID',
-                renderer: (data) => data?.id ? data.xid : `??? [replicated] x ${data['replicas']}`
+                renderer: (data) => data?.id ? data.xid : `${data.xid} [replicated] x ${data['replicas']}`
             },
             'addr': {
                 caption: 'Address',
@@ -117,4 +117,4 @@ const workerManager = (() => {
     return {
         checkLatencies,
     }
-})(ajax, document, event, gui, log, socket);
+})(ajax, document, event, gui, log, socket, utils);

--- a/web/js/workerManager.js
+++ b/web/js/workerManager.js
@@ -1,8 +1,8 @@
 /**
- * Server list module.
+ * Worker manager module.
  * @version 1
  */
-const serverList = (() => {
+const workerManager = (() => {
     const id = 'servers',
         _class = 'server-list',
         trigger = document.getElementById('w'),
@@ -99,8 +99,24 @@ const serverList = (() => {
         panel.toggle(true);
     })
 
+    const checkLatencies = (data) => {
+        const _addresses = data.addresses?.split(',') || [];
+        const timeoutMs = 1111;
+        // deduplicate
+        const addresses = [...new Set(_addresses)];
+
+        return Promise.all(addresses.map(address => {
+            const start = Date.now();
+            return ajax.fetch(`${address}?_=${start}`, {method: "GET", redirect: "follow"}, timeoutMs)
+                .then(() => ({[address]: Date.now() - start}))
+                .catch(() => ({[address]: 9999}));
+        }))
+    };
+
     event.sub(SOCKET_READY, onReady);
     event.sub(GET_SERVER_LIST, onNewData);
 
-    return {}
-})(document, event, gui, log, socket);
+    return {
+        checkLatencies,
+    }
+})(ajax, document, event, gui, log, socket);

--- a/web/js/workerManager.js
+++ b/web/js/workerManager.js
@@ -40,9 +40,6 @@ const workerManager = (() => {
         },
         fields = Object.keys(list);
 
-    // waiting for the socket to request data
-    const onReady = () => handleReload()
-
     const onNewData = (dat = {servers: []}) => {
         panel.setLoad(false);
         index.r();
@@ -113,7 +110,6 @@ const workerManager = (() => {
         }))
     };
 
-    event.sub(SOCKET_READY, onReady);
     event.sub(GET_SERVER_LIST, onNewData);
 
     return {

--- a/web/js/workerManager.js
+++ b/web/js/workerManager.js
@@ -80,6 +80,8 @@ const workerManager = (() => {
     function renderServerChangeEl(server) {
         const handleServerChange = (e) => {
             e.preventDefault();
+            window.location.search = `wid=${server.xid}`
+            // window.location = window.location.pathname;
             console.log(server.addr, server.id);
         }
         return gui.create('a', (el) => {


### PR DESCRIPTION
The current implementation of the worker selection feature supports only uncontrolled automatic selection option based on user's  ping test results.
This feature adds an additional option that enables users to select worker instances at will from a list. This list may contain (depending on the option -- `coordinator.debug`) either IDs of machines or worker instances running on these machines (any server can run multiple worker instances simultaneously).
In order to be able to make a selection, each worker instance or machine has a unique ID that contains a part with the machine identification number. When a user selects a machine, server picks any available on that machine worker randomly.
However, it should be noted that shared games that have game-links can be played only on that worker instance, where it was created initially.

https://user-images.githubusercontent.com/846874/162238365-9c0e256c-1087-4e98-8c0c-53efce7d1dec.mp4