### PR TITLE
Timely auto save

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -85,9 +85,6 @@ worker:
       # Own certs config
       httpsCert:
       httpsKey:
-  autosave:
-    enabled: false
-    period: 3000
   # optional server tag
   tag:
 
@@ -102,6 +99,9 @@ emulator:
     # recalculate emulator game frame size to the given WxH
     width: 320
     height: 240
+
+  # enable autosave for emulator states if set to a non-zero value of seconds
+  autosaveSec: 0
 
   # save directory for emulator states
   # special tag {user} will be replaced with current user's home dir

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -85,6 +85,9 @@ worker:
       # Own certs config
       httpsCert:
       httpsKey:
+  autosave:
+    enabled: false
+    period: 3000
   # optional server tag
   tag:
 

--- a/pkg/config/emulator/config.go
+++ b/pkg/config/emulator/config.go
@@ -13,8 +13,9 @@ type Emulator struct {
 		Width  int
 		Height int
 	}
-	Storage  string
-	Libretro LibretroConfig
+	Storage     string
+	Libretro    LibretroConfig
+	AutosaveSec int
 }
 
 type LibretroConfig struct {

--- a/pkg/config/worker/config.go
+++ b/pkg/config/worker/config.go
@@ -36,10 +36,6 @@ type Worker struct {
 		Secure             bool
 		Zone               string
 	}
-	AutoSave struct {
-		Enabled bool
-		Period  int
-	}
 	Server shared.Server
 	Tag    string
 }

--- a/pkg/config/worker/config.go
+++ b/pkg/config/worker/config.go
@@ -36,6 +36,10 @@ type Worker struct {
 		Secure             bool
 		Zone               string
 	}
+	AutoSave struct {
+		Enabled bool
+		Period  int
+	}
 	Server shared.Server
 	Tag    string
 }


### PR DESCRIPTION
This PR is aiming to support one of the base pillars in a Kubernetes (or basically any cloud) enviroment; resiliency.
By default, all the savings happen manually by the user. If a container or the process itself goes down, there is no guarantee that the clients won't experience total loss of their progress. For the future, re-establishing connection to the client for a seamless QoS, this could also be helpful.

 In this PR, at the creation of a room, just after the streaming starts, another goroutine would be called consisting timely saves with non-busy loop (thanks to @sergystepanov for that!), where the preiod of the saves could be configured from `config.yaml` in seconds (or completely disable with 0).