### PR TITLE
Add NonBlockingSave option for background saving

### DIFF
--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -192,6 +192,7 @@ emulator:
       #       Some cores allow binding multiple devices to a single port (DosBox), but typically,
       #       you should bind just one device to one port.
       #   - kbMouseSupport (bool) -- (temp) a flag if the core needs the keyboard and mouse on the client
+      #   - nonBlockingSave (bool) -- write save file in a non-blocking way, needed for huge save files
       #   - vfr (bool)
       #    (experimental)
       #       Enable variable frame rate only for cores that can't produce a constant frame rate.
@@ -271,6 +272,7 @@ emulator:
           roms: [ "zip", "cue" ]
           folder: dos
           kbMouseSupport: true
+          nonBlockingSave: true
           hid:
             0: [ 257, 513 ]
             1: [ 257, 513 ]

--- a/pkg/config/emulator.go
+++ b/pkg/config/emulator.go
@@ -50,6 +50,7 @@ type LibretroCoreConfig struct {
 	IsGlAllowed     bool
 	KbMouseSupport  bool
 	Lib             string
+	NonBlockingSave bool
 	Options         map[string]string
 	Options4rom     map[string]map[string]string // <(^_^)>
 	Roms            []string

--- a/pkg/worker/caged/libretro/frontend.go
+++ b/pkg/worker/caged/libretro/frontend.go
@@ -158,6 +158,7 @@ func (f *Frontend) LoadCore(emu string) {
 		scale = conf.Scale
 		f.log.Debug().Msgf("Scale: x%v", scale)
 	}
+	f.storage.SetNonBlocking(conf.NonBlockingSave)
 	f.scale = scale
 	f.nano.CoreLoad(meta)
 	f.mu.Unlock()


### PR DESCRIPTION
This feature introduces a new configuration option, `NonBlockingSave`, which allows background saving for large files. With this param the saving process will not block the main thread with all network sockets. By default, it's enabled for the DosBox core.