### PR TITLE
Add the `uniqueSaveDir` option

### DIFF
--- a/.github/workflows/cd/cloudretro.io/config.yaml
+++ b/.github/workflows/cd/cloudretro.io/config.yaml
@@ -29,12 +29,12 @@ emulator:
     logLevel: 1
     cores:
       list:
+        dos:
+          uniqueSaveDir: true
         mame:
           options:
             "fbneo-diagnostic-input": "Hold Start"
         nes:
           scale: 2
-        pcsx:
-          altRepo: true
         snes:
           scale: 2

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -209,6 +209,8 @@ emulator:
       #       - skip_hw_context_destroy -- don't destroy OpenGL context during Libretro core deinit.
       #                                    May help with crashes, for example, with PPSSPP.
       #       - skip_same_thread_save -- skip thread lock save (used with PPSSPP).
+      #   - uniqueSaveDir (bool) -- needed only for cores (like DosBox) that persist their state into one shared file.
+      #       This will allow for concurrent reading and saving of current states.
       list:
         gba:
           lib: mgba_libretro

--- a/pkg/config/emulator.go
+++ b/pkg/config/emulator.go
@@ -55,6 +55,7 @@ type LibretroCoreConfig struct {
 	Options4rom     map[string]map[string]string // <(^_^)>
 	Roms            []string
 	Scale           float64
+	UniqueSaveDir   bool
 	UsesLibCo       bool
 	VFR             bool
 	Width           int

--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -84,3 +84,7 @@ func StatSize(path string) (int64, error) {
 	}
 	return fi.Size(), nil
 }
+
+func RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}

--- a/pkg/worker/caged/libretro/nanoarch/nanoarch.go
+++ b/pkg/worker/caged/libretro/nanoarch/nanoarch.go
@@ -157,6 +157,22 @@ func (n *Nanoarch) WaitReady()                       { <-n.reserved }
 func (n *Nanoarch) Close()                           { n.Stopped.Store(true); n.reserved <- struct{}{} }
 func (n *Nanoarch) SetLogger(log *logger.Logger)     { n.log = log }
 func (n *Nanoarch) SetVideoDebounce(t time.Duration) { n.limiter = NewLimit(t) }
+func (n *Nanoarch) SetSaveDirSuffix(sx string) {
+	if n.cSaveDirectory != nil {
+		C.free(unsafe.Pointer(n.cSaveDirectory))
+	}
+	dir := C.GoString(n.cSaveDirectory) + "/" + sx
+	_ = os.CheckCreateDir(dir)
+	n.cSaveDirectory = C.CString(dir)
+}
+func (n *Nanoarch) DeleteSaveDir() error {
+	if n.cSaveDirectory == nil {
+		return nil
+	}
+
+	dir := C.GoString(n.cSaveDirectory)
+	return os.RemoveAll(dir)
+}
 
 func (n *Nanoarch) CoreLoad(meta Metadata) {
 	var err error

--- a/pkg/worker/caged/libretro/storage.go
+++ b/pkg/worker/caged/libretro/storage.go
@@ -10,6 +10,7 @@ import (
 
 type (
 	Storage interface {
+		MainPath() string
 		GetSavePath() string
 		GetSRAMPath() string
 		SetMainSaveName(name string)
@@ -32,6 +33,7 @@ type (
 	}
 )
 
+func (s *StateStorage) MainPath() string                 { return s.MainSave }
 func (s *StateStorage) SetMainSaveName(name string)      { s.MainSave = name }
 func (s *StateStorage) SetNonBlocking(v bool)            { s.NonBlock = v }
 func (s *StateStorage) GetSavePath() string              { return filepath.Join(s.Path, s.MainSave+".dat") }


### PR DESCRIPTION
This option allows for the safe use of distinct filesystem snapshots of games with some cores (e.g., DosBox). Keep in mind that with this option enabled, game changes won't be saved (the unique save folder will be deleted on exit) until you explicitly call the save (or share) function. Thus, you will need files like dosbox.conf along with the games to use some default behaviors with each new game session.